### PR TITLE
Update README and enhance event processing response

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Centralized dashboard for monitoring Laravel Horizon jobs across multiple servic
 
 ## Requirements
 
-- PHP 8.2+
+- PHP 8.0+
 - Laravel 12 (or 11)
 - MySQL 8 or SQLite
 - Redis (for Reverb broadcasting)
@@ -68,7 +68,7 @@ See [examples/README.md](examples/README.md) for demo apps that push events to t
 
 ## API (v1)
 
-- `POST /api/v1/events` – Agent pushes Horizon events (requires `X-Api-Key`, `X-Hub-Timestamp`, `X-Hub-Signature`).
+- `POST /api/v1/events` – Agent pushes Horizon events (requires `X-Api-Key`, `X-Hub-Timestamp`, `X-Hub-Signature`). Response: `202` with body `{ "accepted": N, "processed": M }`. If some events failed to process, the body also includes `"failed": [ { "index": 0, "error": "Processing failed" }, ... ]` (index is the position in the request payload).
 - Job/queue actions (retry, delete, pause, resume) are available from the Hub UI and proxy to the Agent on each service.
 
 ## License

--- a/app/Contracts/AlertNotifier.php
+++ b/app/Contracts/AlertNotifier.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Contracts;
+
+use App\Models\Alert;
+
+interface AlertNotifier {
+    /**
+     * Send an alert for a single event.
+     *
+     * @param Alert $alert
+     * @param int $serviceId
+     * @param int|null $jobId
+     * @param array $config
+     * @return void
+     */
+    public function send(Alert $alert, int $serviceId, ?int $jobId, array $config): void;
+
+    /**
+     * Send a batched alert.
+     *
+     * @param Alert $alert
+     * @param array<int, array{service_id: int, job_id: int|null, triggered_at: string}> $events
+     * @param array $config
+     * @return void
+     */
+    public function sendBatched(Alert $alert, array $events, array $config): void;
+}

--- a/app/Contracts/EmailAlertNotifier.php
+++ b/app/Contracts/EmailAlertNotifier.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Contracts;
+
+/**
+ * Contract for email-based alert notifications.
+ * Implementations are bound in the container for AlertEngine injection.
+ */
+interface EmailAlertNotifier extends AlertNotifier {
+}

--- a/app/Contracts/SlackAlertNotifier.php
+++ b/app/Contracts/SlackAlertNotifier.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Contracts;
+
+/**
+ * Contract for Slack-based alert notifications.
+ * Implementations are bound in the container for AlertEngine injection.
+ */
+interface SlackAlertNotifier extends AlertNotifier {
+}

--- a/app/Http/Controllers/Api/V1/EventController.php
+++ b/app/Http/Controllers/Api/V1/EventController.php
@@ -43,19 +43,34 @@ class EventController extends Controller {
 
         $service->update(['last_seen_at' => \now(), 'status' => 'online']);
         $events = $request->getEvents();
+        $failed = [];
+        $processed = 0;
 
-        foreach ($events as $event) {
+        foreach ($events as $index => $event) {
             try {
                 $this->processor->process($service, $event);
+                $processed++;
             } catch (\Throwable $e) {
                 Log::error('Horizon Hub: failed to process event', [
                     'service_id' => $service->id,
                     'event' => $event,
                     'error' => $e->getMessage(),
                 ]);
+                $failed[] = [
+                    'index' => $index,
+                    'error' => 'Processing failed',
+                ];
             }
         }
 
-        return \response()->json(['accepted' => \count($events)], 202);
+        $payload = [
+            'accepted' => \count($events),
+            'processed' => $processed,
+        ];
+        if (! empty($failed)) {
+            $payload['failed'] = $failed;
+        }
+
+        return \response()->json($payload, 202);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace App\Providers;
 
+use App\Contracts\EmailAlertNotifier;
+use App\Contracts\SlackAlertNotifier;
+use App\Services\EmailNotifier;
+use App\Services\SlackNotifier;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
@@ -14,7 +18,8 @@ class AppServiceProvider extends ServiceProvider {
      * @return void
      */
     public function register(): void {
-        //
+        $this->app->bind(EmailAlertNotifier::class, EmailNotifier::class);
+        $this->app->bind(SlackAlertNotifier::class, SlackNotifier::class);
     }
 
     /**

--- a/app/Services/AlertEngine.php
+++ b/app/Services/AlertEngine.php
@@ -2,6 +2,8 @@
 
 namespace App\Services;
 
+use App\Contracts\EmailAlertNotifier;
+use App\Contracts\SlackAlertNotifier;
 use App\Models\Alert;
 use App\Models\AlertLog;
 use App\Models\NotificationProvider;
@@ -44,27 +46,27 @@ class AlertEngine {
     /**
      * The email notifier.
      *
-     * @var EmailNotifier
+     * @var EmailAlertNotifier
      */
-    private EmailNotifier $emailNotifier;
+    private EmailAlertNotifier $emailNotifier;
 
     /**
      * The slack notifier.
      *
-     * @var SlackNotifier
+     * @var SlackAlertNotifier
      */
-    private SlackNotifier $slackNotifier;
+    private SlackAlertNotifier $slackNotifier;
 
     /**
      * Construct the alert engine.
      *
-     * @param EmailNotifier $emailNotifier
-     * @param SlackNotifier $slackNotifier
+     * @param EmailAlertNotifier $emailNotifier
+     * @param SlackAlertNotifier $slackNotifier
      * @param AlertRuleEvaluator $ruleEvaluator
      */
     public function __construct(
-        EmailNotifier $emailNotifier,
-        SlackNotifier $slackNotifier,
+        EmailAlertNotifier $emailNotifier,
+        SlackAlertNotifier $slackNotifier,
         AlertRuleEvaluator $ruleEvaluator
     ) {
         $this->emailNotifier = $emailNotifier;

--- a/app/Services/AlertRuleEvaluator.php
+++ b/app/Services/AlertRuleEvaluator.php
@@ -7,6 +7,7 @@ use App\Models\HorizonFailedJob;
 use App\Models\HorizonJob;
 use App\Models\Service;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
 
 class AlertRuleEvaluator {
     /**
@@ -34,12 +35,45 @@ class AlertRuleEvaluator {
      *
      * @param Alert $alert
      * @param int $serviceId
-     * @param int|null $jobId
+     * @param int|null $jobId HorizonJob id (horizon_jobs.id).
      * @return bool
      */
     private function evaluateJobSpecificFailure(Alert $alert, int $serviceId, ?int $jobId): bool {
-        $triggered = true;
-        return $triggered;
+        if ($jobId === null) {
+            return false;
+        }
+
+        $horizonJob = HorizonJob::where('service_id', $serviceId)->where('id', $jobId)->first();
+        if (! $horizonJob) {
+            return false;
+        }
+
+        $failedJob = HorizonFailedJob::where('service_id', $serviceId)
+            ->where('job_uuid', $horizonJob->job_uuid)
+            ->where('failed_at', '>=', \now()->subMinutes(15))
+            ->first();
+
+        if (! $failedJob) {
+            return false;
+        }
+
+        if ($alert->job_type !== null && (string) $alert->job_type !== '') {
+            $payload = $failedJob->payload ?? [];
+            $displayName = \isset($payload['displayName']) ? $payload['displayName'] : null;
+            $rawJob = \isset($payload['job']) ? $payload['job'] : null;
+            $haystack = (string) ($displayName ?? $rawJob ?? '');
+            if (! \str_contains($haystack, $alert->job_type)) {
+                return false;
+            }
+        }
+
+        if (!empty($alert->queue)) {
+            if ((string) $failedJob->queue !== (string) $alert->queue) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -106,29 +140,28 @@ class AlertRuleEvaluator {
         $maxSeconds = (float) (\isset($threshold['seconds']) ? $threshold['seconds'] : 60);
         $minutes = (int) (\isset($threshold['minutes']) ? $threshold['minutes'] : 15);
 
-        $jobs = HorizonJob::where('service_id', $serviceId)
+        $query = HorizonJob::where('service_id', $serviceId)
             ->where('status', 'processed')
             ->whereNotNull('processed_at')
             ->where('processed_at', '>=', \now()->subMinutes($minutes))
-            ->get();
+            ->whereNotNull('queued_at');
 
-        if ($jobs->isEmpty()) {
+        $driver = DB::connection()->getDriverName();
+        if ($driver === 'mysql') {
+            $avg = $query->clone()
+                ->selectRaw('AVG(COALESCE(runtime_seconds, TIMESTAMPDIFF(SECOND, queued_at, processed_at))) as avg_runtime')
+                ->value('avg_runtime');
+        } else {
+            $avg = $query->clone()
+                ->selectRaw('AVG(COALESCE(runtime_seconds, (julianday(processed_at) - julianday(queued_at)) * 86400)) as avg_runtime')
+                ->value('avg_runtime');
+        }
+
+        if ($avg === null) {
             return false;
         }
 
-        $jobsWithRuntime = $jobs->filter(function ($job) {
-            return $job->getRuntimeSeconds() !== null;
-        });
-
-        $avg = $jobsWithRuntime->isEmpty()
-            ? 0.0
-            : $jobsWithRuntime->avg(function ($job) {
-                return $job->getRuntimeSeconds();
-            });
-
-        $triggered = $avg >= $maxSeconds;
-
-        return $triggered;
+        return (float) $avg >= $maxSeconds;
     }
 
     /**

--- a/app/Services/EmailNotifier.php
+++ b/app/Services/EmailNotifier.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Contracts\EmailAlertNotifier;
 use App\Mail\AlertBatchedMail;
 use App\Models\Alert;
 use App\Models\HorizonJob;
@@ -9,7 +10,7 @@ use App\Models\Service;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 
-class EmailNotifier {
+class EmailNotifier implements EmailAlertNotifier {
     /**
      * The maximum length of the exception.
      *

--- a/app/Services/SlackNotifier.php
+++ b/app/Services/SlackNotifier.php
@@ -2,11 +2,12 @@
 
 namespace App\Services;
 
+use App\Contracts\SlackAlertNotifier;
 use App\Models\Alert;
 use App\Models\Service;
 use Illuminate\Support\Facades\Http;
 
-class SlackNotifier {
+class SlackNotifier implements SlackAlertNotifier {
     /**
      * Send an alert.
      *

--- a/config/horizonhub.php
+++ b/config/horizonhub.php
@@ -6,7 +6,10 @@ return [
     | Agent Configuration
     |--------------------------------------------------------------------------
     |
-    | This is used to configure the agent endpoints.
+    | Paths the Hub uses to build action URLs (retry, delete, pause, resume).
+    | They must match the routes published by the horizonhub/agent package on
+    | each Laravel service. When upgrading the Agent, verify compatibility.
+    | See the Agent package README or examples/README.md for route details.
     |
     */
     'agent' => [

--- a/tests/Feature/Api/EventsApiTest.php
+++ b/tests/Feature/Api/EventsApiTest.php
@@ -26,7 +26,7 @@ class EventsApiTest extends TestCase {
             'base_url' => 'https://example.com',
             'status' => 'online',
         ]);
-        $body = json_encode([
+        $body = \json_encode([
             'event_type' => 'JobProcessed',
             'job_id' => 'job-123',
             'queue' => 'redis.default',
@@ -41,7 +41,59 @@ class EventsApiTest extends TestCase {
             'X-Hub-Signature' => $signature,
         ]);
         $response->assertStatus(202);
-        $response->assertJson(['accepted' => 1]);
+        $response->assertJson(['accepted' => 1, 'processed' => 1]);
+    }
+
+    public function test_events_response_includes_processed_and_failed_when_some_events_fail(): void {
+        $service = Service::create([
+            'name' => 'test-service',
+            'api_key' => 'test-api-key-64-chars-long-enough-to-meet-requirementxxxxxxxx',
+            'base_url' => 'https://example.com',
+            'status' => 'online',
+        ]);
+        $payload = [
+            'events' => [
+                [
+                    'event_type' => 'JobProcessed',
+                    'job_id' => 'job-1',
+                    'queue' => 'default',
+                    'status' => 'processed',
+                ],
+                [
+                    'event_type' => 'JobProcessed',
+                    'job_id' => 'job-2',
+                    'queue' => 'default',
+                    'status' => 'processed',
+                ],
+            ],
+        ];
+        $body = \json_encode($payload);
+        $timestamp = (string) \time();
+        $signature = 'sha256=' . \hash_hmac('sha256', "$timestamp.$body", $service->api_key);
+
+        $this->mock(\App\Services\HorizonEventProcessor::class, function ($mock) {
+            $mock->shouldReceive('process')
+                ->once()
+                ->andReturn(null);
+            $mock->shouldReceive('process')
+                ->once()
+                ->andThrow(new \RuntimeException('Test failure'));
+        });
+
+        $response = $this->postJson('/api/v1/events', $payload, [
+            'X-Api-Key' => $service->api_key,
+            'X-Hub-Timestamp' => $timestamp,
+            'X-Hub-Signature' => $signature,
+        ]);
+
+        $response->assertStatus(202);
+        $response->assertJson([
+            'accepted' => 2,
+            'processed' => 1,
+            'failed' => [
+                ['index' => 1, 'error' => 'Processing failed'],
+            ],
+        ]);
     }
 
     public function test_supervisor_looped_creates_or_updates_supervisor_state(): void {
@@ -56,9 +108,9 @@ class EventsApiTest extends TestCase {
             'queue' => 'supervisor-default',
             'status' => 'looped',
         ];
-        $body = json_encode($payload);
-        $timestamp = (string) time();
-        $signature = 'sha256=' . hash_hmac('sha256', $timestamp . '.' . $body, $service->api_key);
+        $body = \json_encode($payload);
+        $timestamp = (string) \time();
+        $signature = 'sha256=' . \hash_hmac('sha256', "$timestamp.$body", $service->api_key);
 
         $response = $this->postJson('/api/v1/events', $payload, [
             'X-Api-Key' => $service->api_key,
@@ -67,7 +119,7 @@ class EventsApiTest extends TestCase {
         ]);
 
         $response->assertStatus(202);
-        $response->assertJson(['accepted' => 1]);
+        $response->assertJson(['accepted' => 1, 'processed' => 1]);
 
         $state = HorizonSupervisorState::where('service_id', $service->id)->where('name', 'supervisor-default')->first();
         $this->assertNotNull($state);

--- a/tests/Unit/AgentProxyServiceTest.php
+++ b/tests/Unit/AgentProxyServiceTest.php
@@ -17,15 +17,15 @@ class AgentProxyServiceTest extends TestCase {
         Http::fake(function ($request) use (&$capturedRequest) {
             $capturedRequest = $request;
 
-            return Http::response(array(), 200);
+            return Http::response([], 200);
         });
 
-        $service = Service::create(array(
+        $service = Service::create([
             'name' => 'svc',
             'api_key' => 'secret-key',
             'base_url' => 'https://example.test',
             'status' => 'online',
-        ));
+        ]);
 
         $proxy = new AgentProxyService();
 
@@ -42,7 +42,7 @@ class AgentProxyServiceTest extends TestCase {
         $this->assertNotNull($timestamp);
         $this->assertNotNull($signature);
 
-        $expectedSignature = 'sha256=' . \hash_hmac('sha256', $timestamp . '.', $service->api_key);
+        $expectedSignature = 'sha256=' . \hash_hmac('sha256', "$timestamp.", $service->api_key);
         $this->assertSame($expectedSignature, $signature);
     }
 }

--- a/tests/Unit/AlertEngineTest.php
+++ b/tests/Unit/AlertEngineTest.php
@@ -35,7 +35,7 @@ class AlertEngineTest extends TestCase {
             'queue' => 'default',
             'payload' => [],
             'exception' => 'err',
-            'failed_at' => now(),
+            'failed_at' => \now(),
         ]);
         HorizonFailedJob::create([
             'service_id' => $service->id,
@@ -43,7 +43,7 @@ class AlertEngineTest extends TestCase {
             'queue' => 'default',
             'payload' => [],
             'exception' => 'err',
-            'failed_at' => now(),
+            'failed_at' => \now(),
         ]);
         $engine = new AlertEngine(
             $this->createMock(EmailNotifier::class),

--- a/tests/Unit/AlertRuleEvaluatorTest.php
+++ b/tests/Unit/AlertRuleEvaluatorTest.php
@@ -1,0 +1,353 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Alert;
+use App\Models\HorizonFailedJob;
+use App\Models\HorizonJob;
+use App\Models\Service;
+use App\Services\AlertRuleEvaluator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AlertRuleEvaluatorTest extends TestCase {
+    use RefreshDatabase;
+
+    private function createService(array $overrides = array()): Service {
+        return Service::create(array_merge(array(
+            'name' => 'test-svc',
+            'api_key' => 'key',
+            'base_url' => 'https://a.com',
+            'status' => 'online',
+        ), $overrides));
+    }
+
+    public function test_job_specific_failure_returns_false_when_job_id_is_null(): void {
+        $service = $this->createService();
+        $alert = Alert::create([
+            'service_id' => $service->id,
+            'rule_type' => 'job_specific_failure',
+            'threshold' => array(),
+        ]);
+        $evaluator = new AlertRuleEvaluator();
+
+        $this->assertFalse($evaluator->evaluate($alert, $service->id, null));
+    }
+
+    public function test_job_specific_failure_returns_false_when_horizon_job_missing(): void {
+        $service = $this->createService();
+        $alert = Alert::create([
+            'service_id' => $service->id,
+            'rule_type' => 'job_specific_failure',
+            'threshold' => array(),
+        ]);
+        $evaluator = new AlertRuleEvaluator();
+
+        $this->assertFalse($evaluator->evaluate($alert, $service->id, 99999));
+    }
+
+    public function test_job_specific_failure_returns_true_when_failed_job_exists_and_matches_no_filters(): void {
+        $service = $this->createService();
+        $alert = Alert::create([
+            'service_id' => $service->id,
+            'rule_type' => 'job_specific_failure',
+            'job_type' => null,
+            'queue' => null,
+            'threshold' => array(),
+        ]);
+        $job = HorizonJob::create([
+            'service_id' => $service->id,
+            'job_uuid' => 'uuid-1',
+            'queue' => 'default',
+            'status' => 'failed',
+            'failed_at' => now(),
+        ]);
+        HorizonFailedJob::create([
+            'service_id' => $service->id,
+            'job_uuid' => 'uuid-1',
+            'queue' => 'default',
+            'payload' => array(),
+            'exception' => 'err',
+            'failed_at' => now(),
+        ]);
+        $evaluator = new AlertRuleEvaluator();
+
+        $this->assertTrue($evaluator->evaluate($alert, $service->id, $job->id));
+    }
+
+    public function test_job_specific_failure_returns_false_when_failed_job_does_not_match_job_type(): void {
+        $service = $this->createService();
+        $alert = Alert::create([
+            'service_id' => $service->id,
+            'rule_type' => 'job_specific_failure',
+            'job_type' => 'OtherJob',
+            'queue' => null,
+            'threshold' => array(),
+        ]);
+        $job = HorizonJob::create([
+            'service_id' => $service->id,
+            'job_uuid' => 'uuid-2',
+            'queue' => 'default',
+            'status' => 'failed',
+            'failed_at' => now(),
+        ]);
+        HorizonFailedJob::create([
+            'service_id' => $service->id,
+            'job_uuid' => 'uuid-2',
+            'queue' => 'default',
+            'payload' => array('displayName' => 'App\\Jobs\\MyJob'),
+            'exception' => 'err',
+            'failed_at' => now(),
+        ]);
+        $evaluator = new AlertRuleEvaluator();
+
+        $this->assertFalse($evaluator->evaluate($alert, $service->id, $job->id));
+    }
+
+    public function test_job_specific_failure_returns_true_when_failed_job_matches_job_type(): void {
+        $service = $this->createService();
+        $alert = Alert::create([
+            'service_id' => $service->id,
+            'rule_type' => 'job_specific_failure',
+            'job_type' => 'MyJob',
+            'queue' => null,
+            'threshold' => array(),
+        ]);
+        $job = HorizonJob::create([
+            'service_id' => $service->id,
+            'job_uuid' => 'uuid-3',
+            'queue' => 'default',
+            'status' => 'failed',
+            'failed_at' => now(),
+        ]);
+        HorizonFailedJob::create([
+            'service_id' => $service->id,
+            'job_uuid' => 'uuid-3',
+            'queue' => 'default',
+            'payload' => array('displayName' => 'App\\Jobs\\MyJob'),
+            'exception' => 'err',
+            'failed_at' => now(),
+        ]);
+        $evaluator = new AlertRuleEvaluator();
+
+        $this->assertTrue($evaluator->evaluate($alert, $service->id, $job->id));
+    }
+
+    public function test_job_type_failure_returns_true_when_recent_failed_job_matches_type(): void {
+        $service = $this->createService();
+        $alert = Alert::create([
+            'service_id' => $service->id,
+            'rule_type' => 'job_type_failure',
+            'job_type' => 'SendEmail',
+            'threshold' => array(),
+        ]);
+        HorizonFailedJob::create([
+            'service_id' => $service->id,
+            'job_uuid' => 'u1',
+            'queue' => 'default',
+            'payload' => array('displayName' => 'App\\Jobs\\SendEmail'),
+            'exception' => 'err',
+            'failed_at' => now(),
+        ]);
+        $evaluator = new AlertRuleEvaluator();
+
+        $this->assertTrue($evaluator->evaluate($alert, $service->id, null));
+    }
+
+    public function test_job_type_failure_returns_false_when_no_matching_failed_job(): void {
+        $service = $this->createService();
+        $alert = Alert::create([
+            'service_id' => $service->id,
+            'rule_type' => 'job_type_failure',
+            'job_type' => 'SendEmail',
+            'threshold' => array(),
+        ]);
+        HorizonFailedJob::create([
+            'service_id' => $service->id,
+            'job_uuid' => 'u1',
+            'queue' => 'default',
+            'payload' => array('displayName' => 'App\\Jobs\\OtherJob'),
+            'exception' => 'err',
+            'failed_at' => now(),
+        ]);
+        $evaluator = new AlertRuleEvaluator();
+
+        $this->assertFalse($evaluator->evaluate($alert, $service->id, null));
+    }
+
+    public function test_failure_count_returns_true_when_threshold_met(): void {
+        $service = $this->createService();
+        $alert = Alert::create([
+            'service_id' => $service->id,
+            'rule_type' => 'failure_count',
+            'threshold' => array('count' => 2, 'minutes' => 60),
+        ]);
+        HorizonFailedJob::create([
+            'service_id' => $service->id,
+            'job_uuid' => 'u1',
+            'queue' => 'default',
+            'payload' => array(),
+            'exception' => 'e',
+            'failed_at' => now(),
+        ]);
+        HorizonFailedJob::create([
+            'service_id' => $service->id,
+            'job_uuid' => 'u2',
+            'queue' => 'default',
+            'payload' => array(),
+            'exception' => 'e',
+            'failed_at' => now(),
+        ]);
+        $evaluator = new AlertRuleEvaluator();
+
+        $this->assertTrue($evaluator->evaluate($alert, $service->id, null));
+    }
+
+    public function test_failure_count_returns_false_when_below_threshold(): void {
+        $service = $this->createService();
+        $alert = Alert::create([
+            'service_id' => $service->id,
+            'rule_type' => 'failure_count',
+            'threshold' => array('count' => 3, 'minutes' => 60),
+        ]);
+        HorizonFailedJob::create([
+            'service_id' => $service->id,
+            'job_uuid' => 'u1',
+            'queue' => 'default',
+            'payload' => array(),
+            'exception' => 'e',
+            'failed_at' => now(),
+        ]);
+        $evaluator = new AlertRuleEvaluator();
+
+        $this->assertFalse($evaluator->evaluate($alert, $service->id, null));
+    }
+
+    public function test_avg_execution_time_returns_true_when_avg_above_threshold(): void {
+        $service = $this->createService();
+        $alert = Alert::create([
+            'service_id' => $service->id,
+            'rule_type' => 'avg_execution_time',
+            'threshold' => array('seconds' => 10, 'minutes' => 60),
+        ]);
+        HorizonJob::create([
+            'service_id' => $service->id,
+            'job_uuid' => 'j1',
+            'queue' => 'default',
+            'status' => 'processed',
+            'processed_at' => now(),
+            'queued_at' => now()->subSeconds(20),
+            'runtime_seconds' => 20,
+        ]);
+        $evaluator = new AlertRuleEvaluator();
+
+        $this->assertTrue($evaluator->evaluate($alert, $service->id, null));
+    }
+
+    public function test_avg_execution_time_returns_false_when_avg_below_threshold(): void {
+        $service = $this->createService();
+        $alert = Alert::create([
+            'service_id' => $service->id,
+            'rule_type' => 'avg_execution_time',
+            'threshold' => array('seconds' => 100, 'minutes' => 60),
+        ]);
+        HorizonJob::create([
+            'service_id' => $service->id,
+            'job_uuid' => 'j1',
+            'queue' => 'default',
+            'status' => 'processed',
+            'processed_at' => now(),
+            'queued_at' => now()->subSeconds(5),
+            'runtime_seconds' => 5,
+        ]);
+        $evaluator = new AlertRuleEvaluator();
+
+        $this->assertFalse($evaluator->evaluate($alert, $service->id, null));
+    }
+
+    public function test_avg_execution_time_returns_false_when_no_jobs(): void {
+        $service = $this->createService();
+        $alert = Alert::create([
+            'service_id' => $service->id,
+            'rule_type' => 'avg_execution_time',
+            'threshold' => array('seconds' => 10, 'minutes' => 60),
+        ]);
+        $evaluator = new AlertRuleEvaluator();
+
+        $this->assertFalse($evaluator->evaluate($alert, $service->id, null));
+    }
+
+    public function test_queue_blocked_returns_true_when_last_processed_too_old(): void {
+        $service = $this->createService();
+        $alert = Alert::create([
+            'service_id' => $service->id,
+            'rule_type' => 'queue_blocked',
+            'threshold' => array('minutes' => 30),
+        ]);
+        HorizonJob::create([
+            'service_id' => $service->id,
+            'job_uuid' => 'j1',
+            'queue' => 'default',
+            'status' => 'processed',
+            'processed_at' => now()->subMinutes(45),
+        ]);
+        $evaluator = new AlertRuleEvaluator();
+
+        $this->assertTrue($evaluator->evaluate($alert, $service->id, null));
+    }
+
+    public function test_queue_blocked_returns_false_when_last_processed_recent(): void {
+        $service = $this->createService();
+        $alert = Alert::create([
+            'service_id' => $service->id,
+            'rule_type' => 'queue_blocked',
+            'threshold' => array('minutes' => 30),
+        ]);
+        HorizonJob::create([
+            'service_id' => $service->id,
+            'job_uuid' => 'j1',
+            'queue' => 'default',
+            'status' => 'processed',
+            'processed_at' => now()->subMinutes(5),
+        ]);
+        $evaluator = new AlertRuleEvaluator();
+
+        $this->assertFalse($evaluator->evaluate($alert, $service->id, null));
+    }
+
+    public function test_worker_offline_returns_true_when_last_seen_too_old(): void {
+        $service = $this->createService(array('last_seen_at' => now()->subMinutes(10)));
+        $alert = Alert::create([
+            'service_id' => $service->id,
+            'rule_type' => 'worker_offline',
+            'threshold' => array('minutes' => 5),
+        ]);
+        $evaluator = new AlertRuleEvaluator();
+
+        $this->assertTrue($evaluator->evaluate($alert, $service->id, null));
+    }
+
+    public function test_worker_offline_returns_false_when_last_seen_recent(): void {
+        $service = $this->createService(array('last_seen_at' => now()->subMinutes(2)));
+        $alert = Alert::create([
+            'service_id' => $service->id,
+            'rule_type' => 'worker_offline',
+            'threshold' => array('minutes' => 5),
+        ]);
+        $evaluator = new AlertRuleEvaluator();
+
+        $this->assertFalse($evaluator->evaluate($alert, $service->id, null));
+    }
+
+    public function test_unknown_rule_type_returns_false(): void {
+        $service = $this->createService();
+        $alert = Alert::create([
+            'service_id' => $service->id,
+            'rule_type' => 'unknown_type',
+            'threshold' => array(),
+        ]);
+        $evaluator = new AlertRuleEvaluator();
+
+        $this->assertFalse($evaluator->evaluate($alert, $service->id, null));
+    }
+}

--- a/tests/Unit/HorizonEventProcessorTest.php
+++ b/tests/Unit/HorizonEventProcessorTest.php
@@ -18,12 +18,12 @@ class HorizonEventProcessorTest extends TestCase {
     public function test_job_failed_event_persists_models_and_triggers_alert_engine(): void {
         Event::fake();
 
-        $service = Service::create(array(
+        $service = Service::create([
             'name' => 'svc',
             'api_key' => 'key',
             'base_url' => 'https://a.com',
             'status' => 'online',
-        ));
+        ]);
 
         $engine = $this->createMock(AlertEngine::class);
         $engine->expects($this->once())
@@ -32,16 +32,16 @@ class HorizonEventProcessorTest extends TestCase {
 
         $processor = new HorizonEventProcessor($engine);
 
-        $event = array(
+        $event = [
             'event_type' => 'JobFailed',
             'job_id' => 'uuid-1',
             'queue' => 'default',
             'name' => 'SomeJob',
-            'payload' => array('displayName' => 'SomeJob'),
+            'payload' => ['displayName' => 'SomeJob'],
             'attempts' => 1,
-            'failed_at' => now()->toIso8601String(),
+            'failed_at' => \now()->toIso8601String(),
             'exception' => 'boom',
-        );
+        ];
 
         $processor->process($service, $event);
 


### PR DESCRIPTION
- Changed PHP requirement from 8.2+ to 8.0+ in README.md.
- Updated API event response to include 'processed' and 'failed' counts in EventController.
- Introduced new AlertNotifier interface and its implementations for email and Slack notifications.
- Enhanced AlertEngine and related services to utilize the new notifier interfaces.
- Added unit tests for alert rule evaluation and event processing to ensure robustness.