### PR TITLE
Implement job and queue pattern handling in alerts

### DIFF
--- a/app/Http/Controllers/Horizon/AlertController.php
+++ b/app/Http/Controllers/Horizon/AlertController.php
@@ -16,6 +16,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 
 class AlertController extends Controller {
@@ -330,6 +331,72 @@ class AlertController extends Controller {
     }
 
     /**
+     * Maximum lines accepted for job or queue pattern textareas.
+     *
+     * @var int
+     */
+    private const ALERT_PATTERN_LINES_MAX = 20;
+
+    /**
+     * Normalize job_patterns[] / queue_patterns[] request input.
+     *
+     * @param mixed $raw
+     * @return list<string>
+     */
+    private function private__sanitizePatternArray(mixed $raw): array {
+        if (! \is_array($raw)) {
+            return [];
+        }
+        $out = [];
+        foreach ($raw as $v) {
+            if (! \is_string($v)) {
+                continue;
+            }
+            $t = \trim($v);
+            if ($t !== '') {
+                $out[] = $t;
+            }
+        }
+        $out = \array_values(\array_unique($out));
+
+        return \array_slice($out, 0, self::ALERT_PATTERN_LINES_MAX);
+    }
+
+    /**
+     * Append optional single job_type field into the pattern list when not already present.
+     *
+     * @param list<string> $patterns
+     * @return list<string>
+     */
+    private function private__mergeJobTypeIntoPatterns(array $patterns, ?string $jobType): array {
+        if ($jobType === null || $jobType === '') {
+            return $patterns;
+        }
+        $jt = \trim($jobType);
+        if ($jt === '') {
+            return $patterns;
+        }
+        if (\in_array($jt, $patterns, true)) {
+            return $patterns;
+        }
+        $merged = $patterns;
+        $merged[] = $jt;
+
+        return \array_slice(\array_values(\array_unique($merged)), 0, self::ALERT_PATTERN_LINES_MAX);
+    }
+
+    /**
+     * Summary for alerts.job_type column (list UI); DB column is varchar(255).
+     */
+    private function private__jobTypeColumnFromPatterns(array $patterns): ?string {
+        if ($patterns === []) {
+            return null;
+        }
+
+        return Str::limit(\implode(', ', $patterns), 252);
+    }
+
+    /**
      * Validate and normalize alert data from the request.
      *
      * @param Request $request
@@ -342,6 +409,10 @@ class AlertController extends Controller {
             'service_id' => 'nullable|exists:services,id',
             'queue' => 'nullable|string|max:255',
             'job_type' => 'nullable|string|max:255',
+            'job_patterns' => 'nullable|array|max:' . self::ALERT_PATTERN_LINES_MAX,
+            'job_patterns.*' => 'nullable|string|max:255',
+            'queue_patterns' => 'nullable|array|max:' . self::ALERT_PATTERN_LINES_MAX,
+            'queue_patterns.*' => 'nullable|string|max:255',
             'thresholdCount' => 'nullable|integer|min:1',
             'thresholdMinutes' => 'nullable|integer|min:1',
             'thresholdSeconds' => 'nullable|numeric|min:0.1',
@@ -355,7 +426,8 @@ class AlertController extends Controller {
         $ruleType = (string) $request->input('rule_type', 'failure_count');
 
         if ($ruleType === 'job_type_failure') {
-            $baseRules['job_type'] = 'required|string|max:255';
+            $baseRules['thresholdMinutes'] = 'required|integer|min:1';
+            $baseRules['thresholdCount'] = 'nullable|integer|min:1';
         }
         if (\in_array($ruleType, ['failure_count', 'avg_execution_time', 'queue_blocked', 'worker_offline', 'supervisor_offline', 'horizon_offline'], true)) {
             $baseRules['thresholdMinutes'] = 'required|integer|min:1';
@@ -366,12 +438,66 @@ class AlertController extends Controller {
         if ($ruleType === 'avg_execution_time') {
             $baseRules['thresholdSeconds'] = 'required|numeric|min:0.1';
         }
+        if ($ruleType === 'job_specific_failure') {
+            $baseRules['thresholdCount'] = 'nullable|integer|min:1';
+            $baseRules['thresholdMinutes'] = 'nullable|integer|min:1';
+        }
 
-        $validated = $request->validate($baseRules);
+        $validator = Validator::make($request->all(), $baseRules);
+        $validator->after(function (\Illuminate\Validation\Validator $v) use ($ruleType, $request): void {
+            $jobPatterns = $this->private__sanitizePatternArray($request->input('job_patterns'));
+            $queuePatterns = $this->private__sanitizePatternArray($request->input('queue_patterns'));
+
+            $jobTypeInput = \trim((string) $request->input('job_type', ''));
+            $jobPatternsMerged = $this->private__mergeJobTypeIntoPatterns($jobPatterns, $jobTypeInput !== '' ? $jobTypeInput : null);
+            if ($ruleType === 'job_type_failure' && $jobPatternsMerged === []) {
+                $v->errors()->add('job_type', 'Enter a job type substring or add at least one job pattern.');
+            }
+            foreach ($jobPatternsMerged as $p) {
+                if (\strlen($p) > 255) {
+                    $v->errors()->add('job_patterns', 'Each job pattern must be at most 255 characters.');
+
+                    break;
+                }
+            }
+            foreach ($queuePatterns as $p) {
+                if (\strlen($p) > 255) {
+                    $v->errors()->add('queue_patterns', 'Each queue name must be at most 255 characters.');
+
+                    break;
+                }
+            }
+            if ($ruleType === 'job_specific_failure') {
+                $minFails = (int) $request->input('thresholdCount', 1);
+                if ($minFails < 1) {
+                    $minFails = 1;
+                }
+                $winMin = $request->input('thresholdMinutes');
+                if ($minFails > 1 && ($winMin === null || $winMin === '' || (int) $winMin < 1)) {
+                    $v->errors()->add('thresholdMinutes', 'Window minutes is required when minimum failures is greater than 1.');
+                }
+            }
+        });
+
+        $validated = $validator->validate();
+
+        $jobPatterns = $this->private__sanitizePatternArray($request->input('job_patterns'));
+        $jobPatterns = $this->private__mergeJobTypeIntoPatterns(
+            $jobPatterns,
+            ! empty($validated['job_type']) ? (string) $validated['job_type'] : null
+        );
+        $queuePatterns = $this->private__sanitizePatternArray($request->input('queue_patterns'));
 
         $threshold = [];
         if (\in_array($ruleType, ['failure_count', 'avg_execution_time', 'queue_blocked', 'worker_offline', 'supervisor_offline', 'horizon_offline'], true)) {
             $threshold['minutes'] = (int) ($validated['thresholdMinutes'] ?? 0);
+        }
+        if ($ruleType === 'job_type_failure') {
+            $threshold['minutes'] = (int) ($validated['thresholdMinutes'] ?? 0);
+            $typeFailCount = (int) ($validated['thresholdCount'] ?? 1);
+            if ($typeFailCount > 1) {
+                $threshold['count'] = $typeFailCount;
+            }
         }
         if ($ruleType === 'failure_count') {
             $threshold['count'] = (int) ($validated['thresholdCount'] ?? 0);
@@ -379,14 +505,47 @@ class AlertController extends Controller {
         if ($ruleType === 'avg_execution_time') {
             $threshold['seconds'] = (float) ($validated['thresholdSeconds'] ?? 0.0);
         }
+        if ($ruleType === 'job_specific_failure') {
+            $jsCount = (int) ($validated['thresholdCount'] ?? 1);
+            if ($jsCount > 1) {
+                $threshold['count'] = $jsCount;
+                $threshold['minutes'] = (int) ($validated['thresholdMinutes'] ?? 15);
+            }
+        }
+
+        $patternRuleTypes = ['job_specific_failure', 'job_type_failure', 'failure_count', 'avg_execution_time'];
+        $queuePatternRuleTypes = ['job_specific_failure', 'job_type_failure', 'failure_count', 'avg_execution_time', 'queue_blocked'];
+        if (\in_array($ruleType, $patternRuleTypes, true)) {
+            if ($jobPatterns !== []) {
+                $threshold['job_patterns'] = $jobPatterns;
+            }
+        }
+        $queuePatternsMerged = $queuePatterns;
+        if ($queuePatternsMerged === [] && ! empty($validated['queue'])) {
+            $queuePatternsMerged = [(string) $validated['queue']];
+        }
+        if (\in_array($ruleType, $queuePatternRuleTypes, true)) {
+            if ($queuePatternsMerged !== []) {
+                $threshold['queue_patterns'] = $queuePatternsMerged;
+            }
+        }
+
+        $queueColumn = null;
+        if (\in_array($ruleType, $queuePatternRuleTypes, true) && $queuePatternsMerged !== []) {
+            $queueColumn = $queuePatternsMerged[0];
+        } elseif (! empty($validated['queue'])) {
+            $queueColumn = (string) $validated['queue'];
+        }
+
+        $jobTypeColumn = $this->private__jobTypeColumnFromPatterns($jobPatterns);
 
         $alertData = [
             'name' => $validated['name'] ?? null,
             'service_id' => ! empty($validated['service_id']) ? (int) $validated['service_id'] : null,
             'rule_type' => $ruleType,
             'threshold' => $threshold,
-            'queue' => ! empty($validated['queue']) ? $validated['queue'] : null,
-            'job_type' => ! empty($validated['job_type']) ? $validated['job_type'] : null,
+            'queue' => $queueColumn,
+            'job_type' => $jobTypeColumn,
             'enabled' => (bool) $validated['enabled'],
             'email_interval_minutes' => (int) $validated['email_interval_minutes'],
         ];

--- a/app/Models/Alert.php
+++ b/app/Models/Alert.php
@@ -12,6 +12,7 @@ class Alert extends Model {
     public const RULE_JOB_SPECIFIC_FAILURE = 'job_specific_failure';
     public const RULE_JOB_TYPE_FAILURE = 'job_type_failure';
     public const RULE_FAILURE_COUNT = 'failure_count';
+    public const RULE_AVG_EXECUTION_TIME = 'avg_execution_time';
     public const RULE_QUEUE_BLOCKED = 'queue_blocked';
     public const RULE_WORKER_OFFLINE = 'worker_offline';
     public const RULE_SUPERVISOR_OFFLINE = 'supervisor_offline';

--- a/app/Services/AlertEngine.php
+++ b/app/Services/AlertEngine.php
@@ -280,6 +280,9 @@ class AlertEngine {
         if ($alert->rule_type === Alert::RULE_FAILURE_COUNT && $eventType !== 'JobFailed') {
             return false;
         }
+        if ($alert->rule_type === Alert::RULE_AVG_EXECUTION_TIME) {
+            return \in_array($eventType, ['JobProcessed', 'JobCompleted'], true);
+        }
         if (\in_array($alert->rule_type, [
             Alert::RULE_QUEUE_BLOCKED,
             Alert::RULE_WORKER_OFFLINE,

--- a/app/Services/AlertRuleEvaluator.php
+++ b/app/Services/AlertRuleEvaluator.php
@@ -6,6 +6,7 @@ use App\Models\Alert;
 use App\Models\Service;
 use App\Services\HorizonApiProxyService;
 use Carbon\Carbon;
+use Illuminate\Support\Collection;
 
 class AlertRuleEvaluator {
 
@@ -67,47 +68,182 @@ class AlertRuleEvaluator {
     }
 
     /**
-     * Evaluate a job specific failure rule.
+     * Resolve the job patterns from the alert threshold.
      *
      * @param Alert $alert
-     * @param int $serviceId
-     * @param string|null $jobUuid
-     * @return bool
+     * @return array<int, string>
      */
-    private function private__evaluateJobSpecificFailure(Alert $alert, int $serviceId, ?string $jobUuid): bool {
-        if (empty($jobUuid)) {
-            return false;
+    private function private__resolveJobPatterns(Alert $alert): array {
+        $threshold = $alert->threshold ?? [];
+        $fromThreshold = $threshold['job_patterns'] ?? [];
+        if (! \is_array($fromThreshold)) {
+            $fromThreshold = [];
         }
-
-        $service = Service::find($serviceId);
-        if (! $service || ! $service->base_url) {
-            return false;
+        $patterns = [];
+        foreach ($fromThreshold as $p) {
+            if (\is_string($p) && $p !== '') {
+                $patterns[] = $p;
+            }
         }
-
-        $response = $this->horizonApi->getFailedJob($service, $jobUuid);
-        $data = $response['data'] ?? null;
-
-        if (! ($response['success'] ?? false) || ! \is_array($data)) {
-            return false;
+        if ($patterns !== []) {
+            return \array_values(\array_unique($patterns));
         }
 
         if ($alert->job_type !== null && (string) $alert->job_type !== '') {
-            $payload = $data['payload'] ?? [];
-            $displayName = $payload['displayName'] ?? null;
-            $rawJob = $payload['job'] ?? null;
-            $haystack = (string) ($displayName ?? $rawJob ?? '');
-            if (! \str_contains($haystack, $alert->job_type)) {
-                return false;
+            return [(string) $alert->job_type];
+        }
+
+        return [];
+    }
+
+    /**
+     * Resolve the queue patterns from the alert threshold.
+     *
+     * @param Alert $alert
+     * @return list<string>
+     */
+    private function private__resolveQueuePatterns(Alert $alert): array {
+        $threshold = $alert->threshold ?? [];
+        $fromThreshold = $threshold['queue_patterns'] ?? [];
+        if (! \is_array($fromThreshold)) {
+            $fromThreshold = [];
+        }
+        $patterns = [];
+        foreach ($fromThreshold as $p) {
+            if (\is_string($p) && $p !== '') {
+                $patterns[] = $p;
+            }
+        }
+        if (! empty($alert->queue)) {
+            $q = (string) $alert->queue;
+            if (! \in_array($q, $patterns, true)) {
+                $patterns[] = $q;
             }
         }
 
-        if (! empty($alert->queue) ) {
-            if ((string) ($data['queue'] ?? '') !== (string) $alert->queue) {
-                return false;
+        return \array_values(\array_unique($patterns));
+    }
+
+    /**
+     * Build the haystack for job pattern matching.
+     *
+     * @param array<string, mixed> $job
+     * @return string
+     */
+    private function private__jobPayloadHaystack(array $job): string {
+        $payload = $job['payload'] ?? [];
+        if (! \is_array($payload)) {
+            $payload = [];
+        }
+        $displayName = $payload['displayName'] ?? null;
+        $rawJob = $payload['job'] ?? null;
+
+        return (string) ($displayName ?? $rawJob ?? '');
+    }
+
+    /**
+     * Empty job patterns means no filter (match any job class).
+     *
+     * @param Alert $alert
+     * @param array<string, mixed> $job
+     */
+    private function private__job_matches_job_patterns(Alert $alert, array $job): bool {
+        $patterns = $this->private__resolveJobPatterns($alert);
+        if ($patterns === []) {
+            return true;
+        }
+        $haystack = $this->private__jobPayloadHaystack($job);
+        foreach ($patterns as $pattern) {
+            if ($pattern !== '' && \str_contains($haystack, $pattern)) {
+                return true;
             }
         }
 
-        return true;
+        return false;
+    }
+
+    /**
+     * Empty queue patterns means no filter (any queue).
+     *
+     * @param array<string, mixed> $job
+     */
+    private function private__job_matches_queue_patterns(Alert $alert, array $job): bool {
+        $patterns = $this->private__resolveQueuePatterns($alert);
+        if ($patterns === []) {
+            return true;
+        }
+        $queue = (string) ($job['queue'] ?? '');
+
+        foreach ($patterns as $pattern) {
+            if ($queue === (string) $pattern) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if the failed job row matches the alert.
+     *
+     * @param Alert $alert
+     * @param array<string, mixed> $job
+     */
+    private function private__failedJobRowMatchesAlert(Alert $alert, array $job): bool {
+        return $this->private__job_matches_queue_patterns($alert, $job)
+            && $this->private__job_matches_job_patterns($alert, $job);
+    }
+
+    /**
+     * Check if the completed job row matches the alert.
+     *
+     * @param Alert $alert
+     * @param array<string, mixed> $job
+     */
+    private function private__completedJobRowMatchesAlert(Alert $alert, array $job): bool {
+        return $this->private__job_matches_queue_patterns($alert, $job)
+            && $this->private__job_matches_job_patterns($alert, $job);
+    }
+
+    /**
+     * Filter the failed jobs in the window.
+     *
+     * @param Collection<int, mixed> $jobs
+     * @param Carbon $cutoff
+     * @return Collection<int, array<string, mixed>>
+     */
+    private function private__filterFailedJobsInWindow(Collection $jobs, Carbon $cutoff): Collection {
+        return $jobs->filter(function ($job) use ($cutoff) {
+            if (! \is_array($job)) {
+                return false;
+            }
+            $failedAt = $this->private__parseFailedAt($job['failed_at'] ?? null);
+
+            return $failedAt !== null && $failedAt->gte($cutoff);
+        });
+    }
+
+    /**
+     * Find the matching failed jobs in the window.
+     *
+     * @param Alert $alert
+     * @param Service $service
+     * @param Carbon $cutoff
+     * @return Collection<int, array<string, mixed>>
+     */
+    private function private__matchingFailedJobsInWindow(Alert $alert, Service $service, Carbon $cutoff): Collection {
+        $response = $this->horizonApi->getFailedJobs($service, ['starting_at' => 0]);
+        $data = $response['data'] ?? null;
+        if (! ($response['success'] ?? false) || ! \is_array($data)) {
+            return collect();
+        }
+        $jobs = collect($data['jobs'] ?? []);
+
+        return $this->private__filterFailedJobsInWindow($jobs, $cutoff)
+            ->filter(function ($job) use ($alert) {
+                return \is_array($job) && $this->private__failedJobRowMatchesAlert($alert, $job);
+            })
+            ->values();
     }
 
     /**
@@ -119,11 +255,61 @@ class AlertRuleEvaluator {
      * @return array{triggered: bool, job_uuids: array<int, string>}
      */
     private function private__evaluateJobSpecificFailureWithJobs(Alert $alert, int $serviceId, ?string $jobUuid): array {
-        $triggered = $this->private__evaluateJobSpecificFailure($alert, $serviceId, $jobUuid);
+        if (empty($jobUuid)) {
+            return ['triggered' => false, 'job_uuids' => []];
+        }
+
+        $service = Service::find($serviceId);
+        if (! $service || ! $service->base_url) {
+            return ['triggered' => false, 'job_uuids' => []];
+        }
+
+        $response = $this->horizonApi->getFailedJob($service, $jobUuid);
+        $data = $response['data'] ?? null;
+        if (! ($response['success'] ?? false) || ! \is_array($data)) {
+            return ['triggered' => false, 'job_uuids' => []];
+        }
+
+        if (! $this->private__failedJobRowMatchesAlert($alert, $data)) {
+            return ['triggered' => false, 'job_uuids' => []];
+        }
+
+        $threshold = $alert->threshold ?? [];
+        $minCount = (int) ($threshold['count'] ?? 1);
+        if ($minCount < 1) {
+            $minCount = 1;
+        }
+        $minutes = (int) ($threshold['minutes'] ?? 15);
+        if ($minutes < 1) {
+            $minutes = 15;
+        }
+
+        if ($minCount <= 1) {
+            return [
+                'triggered' => true,
+                'job_uuids' => [(string) $jobUuid],
+            ];
+        }
+
+        $cutoff = \now()->subMinutes($minutes);
+        $matching = $this->private__matchingFailedJobsInWindow($alert, $service, $cutoff);
+        if ($matching->count() < $minCount) {
+            return ['triggered' => false, 'job_uuids' => []];
+        }
+
+        $jobUuids = $matching->take(self::MAX_TRIGGERING_JOB_UUIDS)
+            ->map(function ($job) {
+                $id = $job['id'] ?? null;
+
+                return $id !== null && $id !== '' ? (string) $id : null;
+            })
+            ->filter()
+            ->values()
+            ->all();
 
         return [
-            'triggered' => $triggered,
-            'job_uuids' => $triggered && $jobUuid !== null && $jobUuid !== '' ? [(string) $jobUuid] : [],
+            'triggered' => true,
+            'job_uuids' => $jobUuids,
         ];
     }
 
@@ -153,6 +339,7 @@ class AlertRuleEvaluator {
         } catch (\Throwable $e) {
             return null;
         }
+
         return null;
     }
 
@@ -161,123 +348,50 @@ class AlertRuleEvaluator {
      *
      * @param Alert $alert
      * @param int $serviceId
-     * @return bool
-     */
-    private function private__evaluateJobTypeFailure(Alert $alert, int $serviceId): bool {
-        if (! $alert->job_type) {
-            return false;
-        }
-
-        $threshold = $alert->threshold ?? [];
-        $minutes = (int) (isset($threshold['minutes']) ? $threshold['minutes'] : 15);
-
-        $service = Service::find($serviceId);
-        if (! $service || ! $service->base_url) {
-            return false;
-        }
-
-        $response = $this->horizonApi->getFailedJobs($service, ['starting_at' => 0]);
-        $data = $response['data'] ?? null;
-
-        if (! ($response['success'] ?? false) || ! \is_array($data)) {
-            return false;
-        }
-
-        $cutoff = \now()->subMinutes($minutes);
-        $recent = collect($data['jobs'] ?? [])
-            ->filter(function ($job) use ($alert, $cutoff) {
-                if (! \is_array($job)) {
-                    return false;
-                }
-
-                $failedAt = $this->private__parseFailedAt($job['failed_at'] ?? null);
-                if ($failedAt === null || $failedAt->lt($cutoff)) {
-                    return false;
-                }
-
-                $payload = $job['payload'] ?? [];
-                $displayName = $payload['displayName'] ?? null;
-                $rawJob = $payload['job'] ?? null;
-                $haystack = (string) ($displayName ?? $rawJob ?? '');
-
-                return \str_contains($haystack, $alert->job_type);
-            })
-            ->isNotEmpty();
-
-        return $recent;
-    }
-
-    /**
-     * Evaluate job type failure and return triggering job UUIDs.
-     *
-     * @param Alert $alert
-     * @param int $serviceId
      * @return array{triggered: bool, job_uuids: array<int, string>}
      */
     private function private__evaluateJobTypeFailureWithJobs(Alert $alert, int $serviceId): array {
-        if (! $alert->job_type) {
+        $patterns = $this->private__resolveJobPatterns($alert);
+        if ($patterns === []) {
             return ['triggered' => false, 'job_uuids' => []];
         }
 
         $threshold = $alert->threshold ?? [];
-        $minutes = (int) (isset($threshold['minutes']) ? $threshold['minutes'] : 15);
+        $minutes = (int) ($threshold['minutes'] ?? 15);
+        if ($minutes < 1) {
+            $minutes = 15;
+        }
+        $minCount = (int) ($threshold['count'] ?? 1);
+        if ($minCount < 1) {
+            $minCount = 1;
+        }
 
         $service = Service::find($serviceId);
         if (! $service || ! $service->base_url) {
             return ['triggered' => false, 'job_uuids' => []];
         }
 
-        $response = $this->horizonApi->getFailedJobs($service, ['starting_at' => 0]);
-        $data = $response['data'] ?? null;
-
-        if (! ($response['success'] ?? false) || ! \is_array($data)) {
+        $cutoff = \now()->subMinutes($minutes);
+        $matching = $this->private__matchingFailedJobsInWindow($alert, $service, $cutoff);
+        if ($matching->count() < $minCount) {
             return ['triggered' => false, 'job_uuids' => []];
         }
 
-        $cutoff = \now()->subMinutes($minutes);
-        $matching = collect($data['jobs'] ?? [])
-            ->filter(function ($job) use ($alert, $cutoff) {
-                if (! \is_array($job)) {
-                    return false;
-                }
-                $failedAt = $this->private__parseFailedAt($job['failed_at'] ?? null);
-                if ($failedAt === null || $failedAt->lt($cutoff)) {
-                    return false;
-                }
-                $payload = $job['payload'] ?? [];
-                $displayName = $payload['displayName'] ?? null;
-                $rawJob = $payload['job'] ?? null;
-                $haystack = (string) ($displayName ?? $rawJob ?? '');
-
-                return \str_contains($haystack, $alert->job_type);
-            })
-            ->take(self::MAX_TRIGGERING_JOB_UUIDS);
-
-        $jobUuids = $matching->map(function ($job) {
+        $forUuids = $matching->take(self::MAX_TRIGGERING_JOB_UUIDS);
+        $jobUuids = $forUuids->map(function ($job) {
             $id = $job['id'] ?? null;
 
             return $id !== null && $id !== '' ? (string) $id : null;
         })->filter()->values()->all();
 
         return [
-            'triggered' => $matching->isNotEmpty(),
+            'triggered' => true,
             'job_uuids' => $jobUuids,
         ];
     }
 
     /**
-     * Evaluate the failure count (boolean only).
-     *
-     * @param Alert $alert
-     * @param int $serviceId
-     * @return bool
-     */
-    private function private__evaluateFailureCount(Alert $alert, int $serviceId): bool {
-        return $this->private__evaluateFailureCountWithJobs($alert, $serviceId)['triggered'];
-    }
-
-    /**
-     * Evaluate the failure count and return triggering job UUIDs.
+     * Evaluate the failure count.
      *
      * @param Alert $alert
      * @param int $serviceId
@@ -285,8 +399,8 @@ class AlertRuleEvaluator {
      */
     private function private__evaluateFailureCountWithJobs(Alert $alert, int $serviceId): array {
         $threshold = $alert->threshold ?? [];
-        $count = (int) (isset($threshold['count']) ? $threshold['count'] : 5);
-        $minutes = (int) (isset($threshold['minutes']) ? $threshold['minutes'] : 15);
+        $count = (int) ($threshold['count'] ?? 5);
+        $minutes = (int) ($threshold['minutes'] ?? 15);
 
         $service = Service::find($serviceId);
         if (! $service || ! $service->base_url) {
@@ -295,28 +409,17 @@ class AlertRuleEvaluator {
 
         $response = $this->horizonApi->getFailedJobs($service, ['starting_at' => 0]);
         $data = $response['data'] ?? null;
-
         if (! ($response['success'] ?? false) || ! \is_array($data)) {
             return ['triggered' => false, 'job_uuids' => []];
         }
 
         $cutoff = \now()->subMinutes($minutes);
         $jobs = collect($data['jobs'] ?? []);
-
-        if ($alert->queue) {
-            $jobs = $jobs->filter(function ($job) use ($alert) {
-                return \is_array($job) && (string) ($job['queue'] ?? '') === (string) $alert->queue;
-            });
-        }
-
-        $inWindow = $jobs->filter(function ($job) use ($cutoff) {
-            if (! \is_array($job)) {
-                return false;
-            }
-            $failedAt = $this->private__parseFailedAt($job['failed_at'] ?? null);
-
-            return $failedAt !== null && $failedAt->gte($cutoff);
-        });
+        $inWindow = $this->private__filterFailedJobsInWindow($jobs, $cutoff)
+            ->filter(function ($job) use ($alert) {
+                return \is_array($job) && $this->private__failedJobRowMatchesAlert($alert, $job);
+            })
+            ->values();
 
         $actual = $inWindow->count();
         $triggered = $actual >= $count;
@@ -345,29 +448,30 @@ class AlertRuleEvaluator {
      *
      * @param Alert $alert
      * @param int $serviceId
-     * @return bool
+     * @return array{triggered: bool, job_uuids: array<int, string>}
      */
-    private function private__evaluateAvgExecutionTime(Alert $alert, int $serviceId): bool {
+    private function private__evaluateAvgExecutionTimeWithJobs(Alert $alert, int $serviceId): array {
         $threshold = $alert->threshold ?? [];
-        $maxSeconds = (float) (isset($threshold['seconds']) ? $threshold['seconds'] : 60);
-        $minutes = (int) (isset($threshold['minutes']) ? $threshold['minutes'] : 15);
+        $maxSeconds = (float) ($threshold['seconds'] ?? 60);
+        $minutes = (int) ($threshold['minutes'] ?? 15);
 
         $service = Service::find($serviceId);
         if (! $service || ! $service->base_url) {
-            return false;
+            return ['triggered' => false, 'job_uuids' => []];
         }
 
         $response = $this->horizonApi->getCompletedJobs($service, ['starting_at' => 0]);
         $data = $response['data'] ?? null;
-
         if (! ($response['success'] ?? false) || ! \is_array($data)) {
-            return false;
+            return ['triggered' => false, 'job_uuids' => []];
         }
 
         $jobs = collect($data['jobs'] ?? []);
         $cutoff = \now()->subMinutes($minutes);
 
-        $durations = $jobs->map(function ($job) use ($cutoff) {
+        $durations = $jobs->filter(function ($job) use ($alert) {
+            return \is_array($job) && $this->private__completedJobRowMatchesAlert($alert, $job);
+        })->map(function ($job) use ($cutoff) {
             if (! \is_array($job)) {
                 return null;
             }
@@ -382,32 +486,23 @@ class AlertRuleEvaluator {
             } catch (\Throwable $e) {
                 return null;
             }
-
             if ($completed->lt($cutoff)) {
                 return null;
             }
-
             $seconds = $queued->diffInSeconds($completed, false);
+
             return $seconds >= 0 ? $seconds : null;
         })->filter(static fn ($v) => $v !== null);
 
         if ($durations->isEmpty()) {
-            return false;
+            return ['triggered' => false, 'job_uuids' => []];
         }
 
         $avg = $durations->average();
+        $triggered = (float) $avg >= $maxSeconds;
 
-        return (float) $avg >= $maxSeconds;
-    }
-
-    /**
-     * @param Alert $alert
-     * @param int $serviceId
-     * @return array{triggered: bool, job_uuids: array<int, string>}
-     */
-    private function private__evaluateAvgExecutionTimeWithJobs(Alert $alert, int $serviceId): array {
         return [
-            'triggered' => $this->private__evaluateAvgExecutionTime($alert, $serviceId),
+            'triggered' => $triggered,
             'job_uuids' => [],
         ];
     }
@@ -421,7 +516,7 @@ class AlertRuleEvaluator {
      */
     private function private__evaluateQueueBlocked(Alert $alert, int $serviceId): bool {
         $threshold = $alert->threshold ?? [];
-        $minutes = (int) (isset($threshold['minutes']) ? $threshold['minutes'] : 30);
+        $minutes = (int) ($threshold['minutes'] ?? 30);
 
         $service = Service::find($serviceId);
         if (! $service || ! $service->base_url) {
@@ -437,9 +532,10 @@ class AlertRuleEvaluator {
 
         $jobs = collect($data['jobs'] ?? []);
 
-        if ($alert->queue) {
+        $queuePatterns = $this->private__resolveQueuePatterns($alert);
+        if ($queuePatterns !== []) {
             $jobs = $jobs->filter(function ($job) use ($alert) {
-                return \is_array($job) && (string) ($job['queue'] ?? '') === (string) $alert->queue;
+                return \is_array($job) && $this->private__job_matches_queue_patterns($alert, $job);
             });
         }
 
@@ -462,12 +558,12 @@ class AlertRuleEvaluator {
             return false;
         }
 
-        $triggered = $lastProcessed->copy()->addMinutes($minutes)->isPast();
-
-        return $triggered;
+        return $lastProcessed->copy()->addMinutes($minutes)->isPast();
     }
 
     /**
+     * Evaluate the queue blocked with jobs.
+     *
      * @param Alert $alert
      * @param int $serviceId
      * @return array{triggered: bool, job_uuids: array<int, string>}
@@ -488,19 +584,19 @@ class AlertRuleEvaluator {
      */
     private function private__evaluateWorkerOffline(Alert $alert, int $serviceId): bool {
         $threshold = $alert->threshold ?? [];
-        $minutes = (int) (isset($threshold['minutes']) ? $threshold['minutes'] : 5);
+        $minutes = (int) ($threshold['minutes'] ?? 5);
 
         $service = Service::find($serviceId);
         if (! $service || ! $service->last_seen_at) {
             return false;
         }
 
-        $triggered = $service->last_seen_at->copy()->addMinutes($minutes)->isPast();
-
-        return $triggered;
+        return $service->last_seen_at->copy()->addMinutes($minutes)->isPast();
     }
 
     /**
+     * Evaluate the worker offline with jobs.
+     *
      * @param Alert $alert
      * @param int $serviceId
      * @return array{triggered: bool, job_uuids: array<int, string>}
@@ -567,6 +663,8 @@ class AlertRuleEvaluator {
     }
 
     /**
+     * Evaluate the supervisor offline with jobs.
+     *
      * @param Alert $alert
      * @param int $serviceId
      * @return array{triggered: bool, job_uuids: array<int, string>}
@@ -595,7 +693,6 @@ class AlertRuleEvaluator {
             return false;
         }
 
-        // If the service itself is marked offline and has been stale long enough, alert immediately.
         if ((string) $service->status === 'offline') {
             if (! $service->last_seen_at) {
                 return true;
@@ -627,6 +724,8 @@ class AlertRuleEvaluator {
     }
 
     /**
+     * Evaluate the Horizon offline rule with jobs.
+     *
      * @param Alert $alert
      * @param int $serviceId
      * @return array{triggered: bool, job_uuids: array<int, string>}

--- a/resources/views/horizon/alerts/form.blade.php
+++ b/resources/views/horizon/alerts/form.blade.php
@@ -6,9 +6,78 @@
         $action = $isEdit ? route('horizon.alerts.update', $alert) : route('horizon.alerts.store');
         /** @var array<int,int> $selectedProviderIds */
         $selectedProviderIds = $selectedProviderIds ?? [];
+        $thresholdForm = $alert->threshold ?? [];
+        $oldJobPatterns = old('job_patterns');
+        if (\is_array($oldJobPatterns)) {
+            $jobPatternsForForm = [];
+            foreach ($oldJobPatterns as $v) {
+                $jobPatternsForForm[] = \is_string($v) ? $v : '';
+            }
+            if ($jobPatternsForForm === []) {
+                $jobPatternsForForm = [''];
+            }
+        } elseif (isset($thresholdForm['job_patterns']) && \is_array($thresholdForm['job_patterns']) && $thresholdForm['job_patterns'] !== []) {
+            $jobPatternsForForm = \array_slice(\array_map('strval', $thresholdForm['job_patterns']), 0, 20);
+        } else {
+            $jobPatternsForForm = [''];
+        }
+        $jobTypeValueForForm = old('job_type');
+        if ($jobTypeValueForForm === null) {
+            $storedJobPatterns = $thresholdForm['job_patterns'] ?? [];
+            $hasStoredJobPatterns = \is_array($storedJobPatterns)
+                && \count(\array_filter($storedJobPatterns, static fn ($x) => \is_string($x) && \trim($x) !== '')) > 0;
+            $jobTypeValueForForm = $hasStoredJobPatterns ? '' : (string) ($alert->job_type ?? '');
+        }
+        $oldQueuePatterns = old('queue_patterns');
+        if (\is_array($oldQueuePatterns)) {
+            $queuePatternsForForm = [];
+            foreach ($oldQueuePatterns as $v) {
+                $queuePatternsForForm[] = \is_string($v) ? $v : '';
+            }
+            if ($queuePatternsForForm === []) {
+                $queuePatternsForForm = [''];
+            }
+        } elseif (isset($thresholdForm['queue_patterns']) && \is_array($thresholdForm['queue_patterns']) && $thresholdForm['queue_patterns'] !== []) {
+            $queuePatternsForForm = \array_slice(\array_map('strval', $thresholdForm['queue_patterns']), 0, 20);
+        } elseif ($alert->queue !== null && (string) $alert->queue !== '') {
+            $queuePatternsForForm = [(string) $alert->queue];
+        } else {
+            $queuePatternsForForm = [''];
+        }
     @endphp
 
-    <div class="max-w-2xl space-y-6" x-data="{ ruleType: '{{ old('rule_type', $alert->rule_type ?? 'failure_count') }}' }">
+    <div
+        class="max-w-2xl space-y-6"
+        x-data="{
+            ruleType: {!! \Illuminate\Support\Js::from(old('rule_type', $alert->rule_type ?? 'failure_count')) !!},
+            jobPatterns: {!! \Illuminate\Support\Js::from($jobPatternsForForm) !!},
+            queuePatterns: {!! \Illuminate\Support\Js::from($queuePatternsForForm) !!},
+            addJobPattern() {
+                if (this.jobPatterns.length < 20) {
+                    this.jobPatterns.push('');
+                }
+            },
+            removeJobPattern(i) {
+                if (this.jobPatterns.length > 1) {
+                    this.jobPatterns.splice(i, 1);
+                } else {
+                    this.jobPatterns[0] = '';
+                }
+            },
+            addQueuePattern() {
+                if (this.queuePatterns.length < 20) {
+                    this.queuePatterns.push('');
+                }
+            },
+            removeQueuePattern(i) {
+                if (this.queuePatterns.length > 1) {
+                    this.queuePatterns.splice(i, 1);
+                } else {
+                    this.queuePatterns[0] = '';
+                }
+            }
+        }"
+    >
         <form method="POST" action="{{ $action }}" class="space-y-6">
             @csrf
             @if($isEdit)
@@ -54,32 +123,101 @@
                         </x-select>
                         @error('rule_type') <span class="text-xs text-destructive">{{ $message }}</span> @enderror
                     </div>
-                    <div class="space-y-2">
-                        <x-input-label for="queue">Queue (optional)</x-input-label>
-                        <x-text-input
-                            type="text"
-                            id="queue"
-                            name="queue"
-                            value="{{ old('queue', $alert->queue) }}"
-                            placeholder="default"
-                            class="w-full"
-                        />
-                        @error('queue') <span class="text-xs text-destructive">{{ $message }}</span> @enderror
+                    <div
+                        class="space-y-2"
+                        x-show="['job_specific_failure','job_type_failure','failure_count','avg_execution_time','queue_blocked'].includes(ruleType)"
+                        x-cloak
+                    >
+                        <x-input-label>Queue (optional)</x-input-label>
+                        <p class="text-xs text-muted-foreground">Exact queue names. Use one row for a single queue, or add rows for several (OR). Leave empty to include all queues.</p>
+                        <div class="space-y-2">
+                            <template x-for="(val, index) in queuePatterns" :key="'qp-' + index">
+                                <div class="flex gap-2 items-center">
+                                    <input
+                                        type="text"
+                                        name="queue_patterns[]"
+                                        x-model="queuePatterns[index]"
+                                        placeholder="default"
+                                        class="flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm font-mono text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                    />
+                                    <x-button
+                                        type="button"
+                                        variant="ghost"
+                                        class="h-9 shrink-0 text-xs"
+                                        @click="removeQueuePattern(index)"
+                                        x-show="queuePatterns.length > 1"
+                                    >
+                                        Remove
+                                    </x-button>
+                                </div>
+                            </template>
+                            <x-button
+                                type="button"
+                                variant="secondary"
+                                class="h-9 text-sm"
+                                @click="addQueuePattern()"
+                                x-show="queuePatterns.length < 20"
+                            >
+                                Add queue
+                            </x-button>
+                        </div>
+                        @error('queue_patterns') <span class="text-xs text-destructive">{{ $message }}</span> @enderror
                     </div>
-                    <div class="space-y-2" x-show="ruleType === 'job_type_failure'">
-                        <x-input-label for="job_type">Job type (class name or substring)</x-input-label>
+                    <div
+                        class="space-y-2"
+                        x-show="['job_specific_failure','job_type_failure','failure_count','avg_execution_time'].includes(ruleType)"
+                        x-cloak
+                    >
+                        <x-input-label>Job (optional)</x-input-label>
+                        <p class="text-xs text-muted-foreground">Substring match on Horizon job class / display name. Multiple patterns match any (OR). Leave all rows empty to include every job type where the rule allows.</p>
+                        <div class="space-y-2">
+                            <template x-for="(val, index) in jobPatterns" :key="'jp-' + index">
+                                <div class="flex gap-2 items-center">
+                                    <input
+                                        type="text"
+                                        name="job_patterns[]"
+                                        x-model="jobPatterns[index]"
+                                        placeholder="App\Jobs\SendEmail"
+                                        class="flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm font-mono text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                    />
+                                    <x-button
+                                        type="button"
+                                        variant="ghost"
+                                        class="h-9 shrink-0 text-xs"
+                                        @click="removeJobPattern(index)"
+                                        x-show="jobPatterns.length > 1"
+                                    >
+                                        Remove
+                                    </x-button>
+                                </div>
+                            </template>
+                            <x-button
+                                type="button"
+                                variant="secondary"
+                                class="h-9 text-sm"
+                                @click="addJobPattern()"
+                                x-show="jobPatterns.length < 20"
+                            >
+                                Add pattern
+                            </x-button>
+                        </div>
+                        @error('job_patterns') <span class="text-xs text-destructive">{{ $message }}</span> @enderror
+                    </div>
+                    <div class="space-y-2" x-show="['job_type_failure','job_specific_failure'].includes(ruleType)" x-cloak>
+                        <x-input-label for="job_type">Job type (optional single substring)</x-input-label>
                         <x-text-input
                             type="text"
                             id="job_type"
                             name="job_type"
-                            value="{{ old('job_type', $alert->job_type) }}"
+                            value="{{ $jobTypeValueForForm }}"
                             placeholder="App\Jobs\ProcessOrder"
                             class="w-full font-mono text-sm"
                         />
+                        <p class="text-xs text-muted-foreground" x-show="ruleType === 'job_type_failure'">Required unless you added at least one job pattern above.</p>
                         @error('job_type') <span class="text-xs text-destructive">{{ $message }}</span> @enderror
                     </div>
 
-                    <template x-if="['failure_count','avg_execution_time','queue_blocked','worker_offline','supervisor_offline','horizon_offline'].includes(ruleType)">
+                    <template x-if="['failure_count','avg_execution_time','queue_blocked','worker_offline','supervisor_offline','horizon_offline','job_type_failure','job_specific_failure'].includes(ruleType)">
                         <div class="space-y-3 pt-2 border-t border-border">
                             <p class="text-xs font-medium text-muted-foreground">Threshold</p>
                             <template x-if="ruleType === 'failure_count'">
@@ -146,6 +284,60 @@
                                         value="{{ old('thresholdMinutes') !== null ? old('thresholdMinutes') : ($alert->threshold['minutes'] ?? 15) }}"
                                     />
                                     @error('thresholdMinutes') <span class="text-xs text-destructive">{{ $message }}</span> @enderror
+                                </div>
+                            </template>
+                            <template x-if="ruleType === 'job_type_failure'">
+                                <div class="flex gap-4 flex-wrap">
+                                    <div class="space-y-2">
+                                        <x-input-label>Window (minutes)</x-input-label>
+                                        <x-text-input
+                                            type="number"
+                                            name="thresholdMinutes"
+                                            min="1"
+                                            class="w-24"
+                                            value="{{ old('thresholdMinutes') !== null ? old('thresholdMinutes') : ($alert->threshold['minutes'] ?? 15) }}"
+                                        />
+                                        @error('thresholdMinutes') <span class="text-xs text-destructive">{{ $message }}</span> @enderror
+                                    </div>
+                                    <div class="space-y-2">
+                                        <x-input-label>Min failures in window</x-input-label>
+                                        <x-text-input
+                                            type="number"
+                                            name="thresholdCount"
+                                            min="1"
+                                            class="w-24"
+                                            value="{{ old('thresholdCount') !== null ? old('thresholdCount') : ($alert->threshold['count'] ?? 1) }}"
+                                        />
+                                        @error('thresholdCount') <span class="text-xs text-destructive">{{ $message }}</span> @enderror
+                                    </div>
+                                </div>
+                            </template>
+                            <template x-if="ruleType === 'job_specific_failure'">
+                                <div class="flex gap-4 flex-wrap">
+                                    <div class="space-y-2">
+                                        <x-input-label>Min failures in window</x-input-label>
+                                        <x-text-input
+                                            type="number"
+                                            name="thresholdCount"
+                                            min="1"
+                                            class="w-24"
+                                            value="{{ old('thresholdCount') !== null ? old('thresholdCount') : ($alert->threshold['count'] ?? 1) }}"
+                                        />
+                                        <p class="text-xs text-muted-foreground">Use &gt; 1 to alert only after N matching failures.</p>
+                                        @error('thresholdCount') <span class="text-xs text-destructive">{{ $message }}</span> @enderror
+                                    </div>
+                                    <div class="space-y-2">
+                                        <x-input-label>Window (minutes)</x-input-label>
+                                        <x-text-input
+                                            type="number"
+                                            name="thresholdMinutes"
+                                            min="1"
+                                            class="w-24"
+                                            value="{{ old('thresholdMinutes') !== null ? old('thresholdMinutes') : ($alert->threshold['minutes'] ?? 15) }}"
+                                        />
+                                        <p class="text-xs text-muted-foreground">Required when min failures &gt; 1.</p>
+                                        @error('thresholdMinutes') <span class="text-xs text-destructive">{{ $message }}</span> @enderror
+                                    </div>
                                 </div>
                             </template>
                         </div>

--- a/resources/views/horizon/alerts/index.blade.php
+++ b/resources/views/horizon/alerts/index.blade.php
@@ -67,8 +67,30 @@
                                 {{ $alert->service_id ? $alert->service->name : 'All' }}
                             </td>
                             <td class="px-4 py-2.5 text-sm font-mono text-muted-foreground" data-column-id="rule_type">{{ $alert->rule_type }}</td>
-                            <td class="px-4 py-2.5 text-sm text-muted-foreground" data-column-id="queue">{{ $alert->queue ?? '–' }}</td>
-                            <td class="px-4 py-2.5 text-sm text-muted-foreground" data-column-id="job_type">{{ $alert->job_type ?? '–' }}</td>
+                            <td class="px-4 py-2.5 text-sm text-muted-foreground" data-column-id="queue">
+                                @php
+                                    $qps = isset($alert->threshold['queue_patterns']) && is_array($alert->threshold['queue_patterns']) ? $alert->threshold['queue_patterns'] : [];
+                                @endphp
+                                @if(\count($qps) > 1)
+                                    {{ $qps[0] }} (+{{ \count($qps) - 1 }})
+                                @elseif(\count($qps) === 1)
+                                    {{ $qps[0] }}
+                                @else
+                                    {{ $alert->queue ?? '–' }}
+                                @endif
+                            </td>
+                            <td class="px-4 py-2.5 text-sm text-muted-foreground" data-column-id="job_type">
+                                @php
+                                    $jps = isset($alert->threshold['job_patterns']) && is_array($alert->threshold['job_patterns']) ? $alert->threshold['job_patterns'] : [];
+                                @endphp
+                                @if(\count($jps) > 1)
+                                    {{ \Illuminate\Support\Str::limit((string) $jps[0], 24) }} (+{{ \count($jps) - 1 }})
+                                @elseif(\count($jps) === 1)
+                                    {{ \Illuminate\Support\Str::limit((string) $jps[0], 32) }}
+                                @else
+                                    {{ $alert->job_type ? \Illuminate\Support\Str::limit($alert->job_type, 32) : '–' }}
+                                @endif
+                            </td>
                             <td class="px-4 py-2.5" data-column-id="enabled">
                                 @if($alert->enabled)
                                     <span class="badge-success">On</span>

--- a/resources/views/horizon/alerts/show.blade.php
+++ b/resources/views/horizon/alerts/show.blade.php
@@ -74,7 +74,21 @@
                     @endif
                     @php
                         $threshold = $ruleConfig['threshold'] ?? [];
+                        $jobPatternsShow = isset($threshold['job_patterns']) && \is_array($threshold['job_patterns']) ? $threshold['job_patterns'] : [];
+                        $queuePatternsShow = isset($threshold['queue_patterns']) && \is_array($threshold['queue_patterns']) ? $threshold['queue_patterns'] : [];
                     @endphp
+                    @if(\count($jobPatternsShow) > 0)
+                        <div class="sm:col-span-2">
+                            <dt class="label-muted">Job</dt>
+                            <dd class="mt-0.5 text-foreground font-mono text-xs whitespace-pre-wrap">{{ \implode("\n", \array_map('strval', $jobPatternsShow)) }}</dd>
+                        </div>
+                    @endif
+                    @if(\count($queuePatternsShow) > 0)
+                        <div class="sm:col-span-2">
+                            <dt class="label-muted">Queue patterns</dt>
+                            <dd class="mt-0.5 text-foreground font-mono text-xs whitespace-pre-wrap">{{ \implode("\n", \array_map('strval', $queuePatternsShow)) }}</dd>
+                        </div>
+                    @endif
                     @if(!empty($threshold))
                         <div>
                             <dt class="label-muted">Threshold</dt>


### PR DESCRIPTION
- Added methods to sanitize and merge job and queue patterns in the AlertController.
- Updated validation rules to include job_patterns and queue_patterns with maximum line limits.
- Enhanced the AlertEngine to evaluate alerts based on average execution time and job-specific failure rules.
- Modified the alert forms and views to support multiple job and queue patterns, improving user experience.
- Displayed job and queue patterns in the alerts index and show views for better visibility.