### PR TITLE
Refactor Horizon header labels for consistency and refactor theme impl

### DIFF
--- a/app/Http/Controllers/Horizon/AlertController.php
+++ b/app/Http/Controllers/Horizon/AlertController.php
@@ -57,7 +57,7 @@ class AlertController extends Controller
 
         return \view('horizon.alerts.index', [
             'alerts' => $alerts,
-            'header' => 'Horizon Hub – Alerts',
+            'header' => 'Alerts',
         ]);
     }
 
@@ -170,7 +170,7 @@ class AlertController extends Controller
                 'service_id' => $serviceFilter !== null ? (string) $serviceFilter : '',
                 'per_page' => $perPage,
             ],
-            'header' => "Horizon Hub – $alertName",
+            'header' => $alertName,
         ]);
     }
 

--- a/app/Http/Controllers/Horizon/JobController.php
+++ b/app/Http/Controllers/Horizon/JobController.php
@@ -56,7 +56,7 @@ class JobController extends Controller
                 'serviceIds' => $index['serviceFilterIds'],
                 'search' => $index['search'],
             ],
-            'header' => 'Horizon Hub – Jobs',
+            'header' => 'Jobs',
         ]);
     }
 

--- a/app/Http/Controllers/Horizon/MetricsController.php
+++ b/app/Http/Controllers/Horizon/MetricsController.php
@@ -25,7 +25,7 @@ class MetricsController extends Controller
         return \view('horizon.metrics.index', \array_merge($this->metricsDashboard->build($serviceIds), [
             'services' => $services,
             'serviceIds' => $serviceIds,
-            'header' => 'Horizon Hub – Metrics',
+            'header' => 'Metrics',
         ]));
     }
 }

--- a/app/Http/Controllers/Horizon/ProviderController.php
+++ b/app/Http/Controllers/Horizon/ProviderController.php
@@ -81,7 +81,7 @@ class ProviderController extends Controller
             'provider' => $provider,
             'webhookUrl' => $webhookUrl,
             'emailTo' => $emailTo,
-            'header' => 'Horizon Hub – '.($provider->exists ? 'Edit provider' : 'New provider'),
+            'header' => $provider->exists ? 'Edit provider' : 'New provider',
         ]);
     }
 

--- a/app/Http/Controllers/Horizon/QueueController.php
+++ b/app/Http/Controllers/Horizon/QueueController.php
@@ -29,7 +29,7 @@ class QueueController extends Controller
             'services' => Service::orderBy('name')->get(),
             'totalJobs' => $queues->sum('job_count'),
             'serviceIds' => $serviceFilterIds,
-            'header' => 'Horizon Hub – Queues',
+            'header' => 'Queues',
         ]);
     }
 }

--- a/app/Http/Controllers/Horizon/ServiceController.php
+++ b/app/Http/Controllers/Horizon/ServiceController.php
@@ -26,7 +26,7 @@ class ServiceController extends Controller
 
         return \view('horizon.services.index', [
             'services' => $services,
-            'header' => 'Horizon Hub – Services',
+            'header' => 'Services',
         ]);
     }
 
@@ -143,7 +143,7 @@ class ServiceController extends Controller
 
         return \view('horizon.services.show', \array_merge($data, [
             'service' => $service,
-            'header' => "Horizon Hub – {$service->name}",
+            'header' => $service->name,
         ]));
     }
 

--- a/app/Services/Alerts/AlertUpsertService.php
+++ b/app/Services/Alerts/AlertUpsertService.php
@@ -42,7 +42,7 @@ class AlertUpsertService
             'ruleTypes' => $ruleTypes,
             'selectedProviderIds' => $alert->exists ? $alert->notificationProviders()->pluck('notification_providers.id')->all() : [],
             'selectedServiceIds' => $alert->exists ? $alert->scopedServiceIds() : [],
-            'header' => "Horizon Hub – $header",
+            'header' => $header,
         ];
     }
 

--- a/resources/js/components/theme.js
+++ b/resources/js/components/theme.js
@@ -1,21 +1,58 @@
 var THEME_KEY = 'horizonhub_theme';
 
 /**
- * Apply the theme to the document.
- * @returns {void}
+ * Validated theme value from localStorage.
+ * @returns {'light'|'dark'|'system'}
  */
-export function applyTheme() {
-    document.documentElement.classList.toggle('dark', getResolvedDark());
+export function getStoredTheme() {
+    return localStorage.getItem(THEME_KEY);
 }
 
 /**
- * Get the resolved dark theme.
+ * Whether the given theme preference resolves to dark mode for the document.
+ * @param {'light'|'dark'|'system'} theme
  * @returns {boolean}
  */
-function getResolvedDark() {
-    var t = localStorage.getItem(THEME_KEY) || 'light';
-    if (t === 'system') {
+export function resolveDark(theme) {
+    if (theme === 'system') {
         return window.matchMedia('(prefers-color-scheme: dark)').matches;
     }
-    return t === 'dark';
+
+    return theme === 'dark';
+}
+
+/**
+ * Set theme and dispatch `apply-theme` event.
+ * @param {'light'|'dark'|'system'} theme
+ * @returns {'light'|'dark'|'system'}
+ */
+export function setTheme(theme) {
+    localStorage.setItem(THEME_KEY, theme);
+    if (typeof window !== 'undefined') {
+        window.__horizonhub_theme = theme;
+    }
+    window.dispatchEvent(new CustomEvent('apply-theme'));
+    return theme;
+}
+
+/**
+ * Apply the theme to the document from localStorage.
+ * @returns {void}
+ */
+export function applyTheme() {
+    if (typeof window !== 'undefined') {
+        window.__horizonhub_theme = getStoredTheme();
+    }
+    document.documentElement.classList.toggle('dark', resolveDark(getStoredTheme()));
+}
+
+if (typeof window !== 'undefined') {
+    window.horizonHubTheme = {
+        getStoredTheme: getStoredTheme,
+        resolveDark: resolveDark,
+        applyFromPreference: function (theme) {
+            document.documentElement.classList.toggle('dark', resolveDark(theme));
+        },
+        setTheme: setTheme,
+    };
 }

--- a/resources/views/horizon/settings/index.blade.php
+++ b/resources/views/horizon/settings/index.blade.php
@@ -54,24 +54,22 @@
                     <h2 class="text-section-title text-foreground mb-3">Theme</h2>
                     <p class="text-sm text-muted-foreground mb-4">Choose how Horizon Hub looks. You can pick a theme or use your system setting.</p>
                     <div class="flex flex-wrap gap-2"
-                        x-data="{ theme: (window.__horizonhub_theme || 'light') }"
-                        x-init="theme = (window.__horizonhub_theme || (function(){ var t = localStorage.getItem('horizonhub_theme'); return (t === 'light' || t === 'dark' || t === 'system') ? t : 'light'; })())"
-                        @theme-changed.window="theme = $event.detail"
-                        @apply-theme.window="theme = (window.__horizonhub_theme || (function(){ var t = localStorage.getItem('horizonhub_theme'); return (t === 'light' || t === 'dark' || t === 'system') ? t : 'light'; })())">
+                        x-data="{ theme: window.horizonHubTheme.getStoredTheme() }"
+                        @apply-theme.window="theme = window.horizonHubTheme.getStoredTheme()">
                         <button type="button"
-                            @click="theme = 'light'; localStorage.setItem('horizonhub_theme', 'light'); window.dispatchEvent(new CustomEvent('theme-changed', { detail: 'light' })); window.dispatchEvent(new CustomEvent('apply-theme'));"
+                            @click="theme = window.horizonHubTheme.setTheme('light')"
                             :class="theme === 'light' ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground hover:bg-muted/80'"
                             class="rounded-lg border border-border px-4 py-2 text-sm font-medium transition-colors">
                             Light
                         </button>
                         <button type="button"
-                            @click="theme = 'dark'; localStorage.setItem('horizonhub_theme', 'dark'); window.dispatchEvent(new CustomEvent('theme-changed', { detail: 'dark' })); window.dispatchEvent(new CustomEvent('apply-theme'));"
+                            @click="theme = window.horizonHubTheme.setTheme('dark')"
                             :class="theme === 'dark' ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground hover:bg-muted/80'"
                             class="rounded-lg border border-border px-4 py-2 text-sm font-medium transition-colors">
                             Dark
                         </button>
                         <button type="button"
-                            @click="theme = 'system'; localStorage.setItem('horizonhub_theme', 'system'); window.dispatchEvent(new CustomEvent('theme-changed', { detail: 'system' })); window.dispatchEvent(new CustomEvent('apply-theme'));"
+                            @click="theme = window.horizonHubTheme.setTheme('system')"
                             :class="theme === 'system' ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground hover:bg-muted/80'"
                             class="rounded-lg border border-border px-4 py-2 text-sm font-medium transition-colors">
                             System

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,38 +1,27 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}"
         x-data="{
-            theme: (window.__horizonhub_theme || 'light'),
-            get dark() {
-                if (this.theme === 'system') return window.matchMedia('(prefers-color-scheme: dark)').matches;
-                return this.theme === 'dark';
-            }
+            theme: window.horizonHubTheme.getStoredTheme(),
         }"
-        x-init="document.documentElement.classList.toggle('dark', dark)"
-        x-effect="document.documentElement.classList.toggle('dark', dark)"
-        @theme-changed.window="theme = $event.detail; if (theme) { localStorage.setItem('horizonhub_theme', theme); window.__horizonhub_theme = theme }"
-        @apply-theme.window="theme = (window.__horizonhub_theme || (function(){ var t = localStorage.getItem('horizonhub_theme'); if (t === 'light' || t === 'dark' || t === 'system') return t; })()); window.__horizonhub_theme = theme"
-        @toggle-dark.window="theme = theme === 'dark' ? 'light' : 'dark'; localStorage.setItem('horizonhub_theme', theme); window.__horizonhub_theme = theme">
+        x-init="window.horizonHubTheme.applyFromPreference(theme)"
+        x-effect="window.horizonHubTheme.applyFromPreference(theme)"
+    >
     <head>
+        <!-- Meta -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="turbo-prefetch" content="false">
         <meta name="csrf-token" content="{{ csrf_token() }}">
-        <script>
-            (function () {
-                var t = localStorage.getItem('horizonhub_theme');
-                if (!t || (t !== 'light' && t !== 'dark' && t !== 'system')) t = 'light';
-                window.__horizonhub_theme = t;
-                var isDark = t === 'system' ? window.matchMedia('(prefers-color-scheme: dark)').matches : (t === 'dark');
-                document.documentElement.classList.toggle('dark', isDark);
-            })();
-        </script>
+        <meta name="view-transition" content="same-origin" />
+
+        <!-- Title -->
         <title>{{ \config('app.name') }}</title>
+
+        <!-- Links -->
         <link rel="icon" type="image/svg+xml" href="{{ asset('logo.svg') }}">
         <link rel="preload" href="{{ asset('logo.svg') }}" as="image">
         <link rel="preconnect" href="https://fonts.bunny.net">
         <link href="https://fonts.bunny.net/css?family=plus-jakarta-sans:400,500,600,700&display=swap" rel="stylesheet" />
-
-        <meta name="view-transition" content="same-origin" />
 
         <!-- Scripts -->
         <script src="https://cdn.jsdelivr.net/npm/echarts@5.4.3/dist/echarts.min.js"></script>
@@ -48,72 +37,22 @@
         x-init="document.body.classList.toggle('sidebar-collapsed', !sidebarOpen)"
         x-effect="localStorage.setItem('horizon_sidebar_open', sidebarOpen); document.body.classList.toggle('sidebar-collapsed', !sidebarOpen)"
         @toggle-sidebar.window="sidebarOpen = !sidebarOpen; window.dispatchEvent(new CustomEvent('sidebar-open-changed', { detail: sidebarOpen }))">
-        <script>
-            (() => {
-                var t = window.__horizonhub_theme || localStorage.getItem('horizonhub_theme');
-                if (!t || (t !== 'light' && t !== 'dark' && t !== 'system')) t = 'light';
-                window.__horizonhub_theme = t;
-                var isDark = t === 'system' ? window.matchMedia('(prefers-color-scheme: dark)').matches : (t === 'dark');
-                document.documentElement.classList.toggle('dark', isDark);
-            })();
-            document.body.addEventListener('click', e => {
-                var btn = e.target.closest('[data-queue-action]');
-                if (!btn || !btn.closest('[data-table-body="horizon-queue-list"]')) return;
-                e.preventDefault();
-                var action = btn.getAttribute('data-queue-action');
-                var serviceId = btn.getAttribute('data-service-id');
-                var queue = btn.getAttribute('data-queue');
-                if (!action || !serviceId || !queue) return;
-                var apiUrl = '/horizon/queues/' + encodeURIComponent(queue) + '/' + action;
-                var token = document.querySelector('meta[name="csrf-token"]');
-                btn.disabled = true;
-                btn.setAttribute('data-loading', 'true');
-                fetch(apiUrl, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'Accept': 'application/json',
-                        'X-CSRF-TOKEN': token ? token.getAttribute('content') : ''
-                    },
-                    body: JSON.stringify({ service_id: serviceId })
-                }).then(r => {
-                    btn.disabled = false;
-                    btn.removeAttribute('data-loading');
-                    if (!r.ok) {
-                        return r.json().then(body => {
-                            if (window.toast) window.toast.error(body.message || 'Request failed');
-                            else alert(body.message || 'Request failed');
-                        }).catch(() => {
-                            if (window.toast) window.toast.error('Request failed');
-                            else alert('Request failed');
-                        });
-                    }
-                    if (window.toast) window.toast.success(action === 'pause' ? 'Queue paused.' : 'Queue resumed.');
-                    window.dispatchEvent(new CustomEvent('horizon-queue-action-done'));
-                }).catch(() => {
-                    btn.disabled = false;
-                    btn.removeAttribute('data-loading');
-                    if (window.toast) window.toast.error('Network error');
-                    else alert('Network error');
-                });
-            });
-        </script>
         <div class="app-layout flex min-h-screen flex-1 flex-row lg:flex-row">
             @include('partials.navigation')
             <div class="flex min-h-0 min-w-0 flex-1 flex-col pt-12 lg:pt-0">
             @if (isset($header))
                 <header class="shrink-0 border-b border-border bg-card">
-                    <div class="max-w-6xl mx-16 flex h-12 items-center">
+                    <div class="max-w-6xl mx-8 flex h-12 items-center">
                         <h1 class="text-page-title text-foreground">{{ $header }}</h1>
                     </div>
                 </header>
             @endif
-            <main class="flex-1 p-4 lg:p-6">
-                @yield('content')
-                @isset($slot)
-                    {{ $slot }}
-                @endisset
-            </main>
+                <main class="flex-1 p-4 lg:p-6">
+                    @yield('content')
+                    @isset($slot)
+                        {{ $slot }}
+                    @endisset
+                </main>
             </div>
         </div>
     </body>


### PR DESCRIPTION
- Updated header labels across various Horizon controllers to remove the "Horizon Hub – " prefix, simplifying the display titles.
- Ensured uniformity in header presentation for alerts, jobs, metrics, queues, services, and provider views, enhancing user experience and clarity.