### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   tests-and-style:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/enegalan/horizonhub/security/code-scanning/1](https://github.com/enegalan/horizonhub/security/code-scanning/1)

To fix this, add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to the minimum required scope.  
Best single fix without changing functionality: add a root-level permissions block with `contents: read` right after the trigger section (`on:`), before `jobs:`. This applies to all jobs unless overridden and matches the needs of the shown steps (checkout/build/test). No imports, methods, or dependencies are needed—just YAML configuration in `.github/workflows/ci.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
