### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/resources/js/lib/dom.js
+++ b/resources/js/lib/dom.js
@@ -10,21 +10,12 @@ export function getCssHsl(varName) {
 }
 
 /**
- * The textarea element used to decode HTML entities.
- * @type {HTMLTextAreaElement|null}
- */
-var _textarea = null;
-/**
  * Decode HTML entities from a string.
  * @param {string} value
  * @returns {string}
  */
 export function decodeHtmlEntities(value) {
     if (typeof document === 'undefined') return value;
-    if (!_textarea) {
-        _textarea = document.createElement('textarea');
-    }
-    _textarea.innerHTML = value;
-
-    return _textarea.value;
+    var doc = new DOMParser().parseFromString(String(value), 'text/html');
+    return doc.documentElement.textContent || '';
 }


### PR DESCRIPTION
Potential fix for [https://github.com/enegalan/horizonhub/security/code-scanning/2](https://github.com/enegalan/horizonhub/security/code-scanning/2)

General fix: avoid any API that parses untrusted strings as HTML (`innerHTML`, `outerHTML`, `insertAdjacentHTML`, `$()` HTML parsing paths, etc.) when the goal is plain text/entity decoding.

Best fix here (without changing behavior): in `resources/js/lib/dom.js`, replace the textarea-based decode implementation with a parser that reads text via `textContent` from a parsed document, never assigning to `innerHTML` on a DOM node in the current document. `DOMParser.parseFromString(..., 'text/html')` is appropriate and keeps entity-decoding behavior while removing the flagged sink.

Concretely:
- Edit `decodeHtmlEntities` in `resources/js/lib/dom.js`.
- Remove `_textarea` cache and the `_textarea.innerHTML = value; return _textarea.value;` logic.
- Replace with:
  - SSR guard as-is.
  - Normalize input to string.
  - `var doc = new DOMParser().parseFromString(String(value), 'text/html');`
  - `return doc.documentElement.textContent || '';`

No other file changes are required; `json-tree.js` can continue calling `decodeHtmlEntities` unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
