### PR TITLE
Add method ordering and private method prefix rules

### DIFF
--- a/.cursor/rules/methods-order.mdc
+++ b/.cursor/rules/methods-order.mdc
@@ -1,0 +1,34 @@
+---
+description: Ordering criteria for class methods by visibility and alphabetical order
+alwaysApply: true
+---
+
+# Methods Order
+
+## Ordering criteria
+
+- Declare methods ordered by visibility, from most to least accessible.
+- Top of the class: `public` methods (and exported/framework entrypoints such as controller actions, route handlers, event handlers, and magic methods).
+- Middle: `protected` methods.
+- Bottom: `private` methods.
+
+## Grouping rules
+
+- Keep all methods of the same visibility grouped together; do not interleave visibilities.
+- Within each visibility group, order methods alphabetically by method name (A-Z).
+- For case differences, apply case-insensitive alphabetical ordering.
+- Constructors, `__invoke`, and other lifecycle/magic methods remain at the top of the `public` group.
+- Static methods follow the same visibility ordering and stay grouped with their visibility block.
+
+## Scope
+
+- Applies to PHP classes, traits, and abstract classes across the project.
+- Applies to JavaScript/TypeScript classes: `public` (or unmarked) first, `protected` next, `#private` or `private` last.
+- Does not require reordering unrelated methods when editing a file; only ensure new or modified methods respect this order.
+- Excludes Laravel framework-convention files and folders such as `database/migrations`, `database/seeders`, `database/factories`, `routes`, `config`, `bootstrap`, `app/Providers`, and `app/Console/Commands`.
+
+## Exceptions
+
+- Do not reorder methods if it conflicts with a framework-imposed order (e.g., generated stubs with required positions).
+- Do not reorder methods in files explicitly marked as generated or vendor code.
+- Do not apply this rule to Laravel-convention files where framework readability and conventional order are preferred (for example, `database/migrations`).

--- a/.cursor/rules/private-methods-prefix.mdc
+++ b/.cursor/rules/private-methods-prefix.mdc
@@ -1,0 +1,28 @@
+---
+description: Require private methods to use private__ prefix
+alwaysApply: true
+---
+
+# Private Methods Prefix
+
+## Naming rule
+
+- All `private` methods must start with the exact prefix `private__`.
+- The prefix is mandatory for PHP, JavaScript, and TypeScript private methods.
+- Valid examples: `private__buildPayload`, `private__normalize_metrics`.
+
+## Invalid names
+
+- `buildPayload`
+- `_buildPayload`
+- `private_buildPayload`
+
+## Scope
+
+- Applies to classes, traits, and abstract classes in the project.
+- Applies to newly created or modified private methods.
+
+## Exceptions
+
+- Do not rename methods in generated or vendor code.
+- Do not rename external API/framework methods that require fixed names.

--- a/app/Http/Controllers/Horizon/AlertController.php
+++ b/app/Http/Controllers/Horizon/AlertController.php
@@ -44,6 +44,62 @@ class AlertController extends Controller
     }
 
     /**
+     * Show the form to create a new alert.
+     */
+    public function create(): View
+    {
+        return \view('horizon.alerts.form', $this->alertUpsert->buildFormViewVariables(new Alert));
+    }
+
+    /**
+     * Delete an alert.
+     */
+    public function destroy(Alert $alert): RedirectResponse
+    {
+        $name = $alert->name ?: ('Alert #'.$alert->id);
+        $alert->delete();
+
+        return redirect()
+            ->route('horizon.alerts.index')
+            ->with('status', "Alert $name deleted.");
+    }
+
+    /**
+     * Show the form to edit an existing alert.
+     */
+    public function edit(Alert $alert): View
+    {
+        return \view('horizon.alerts.form', $this->alertUpsert->buildFormViewVariables($alert));
+    }
+
+    /**
+     * Evaluate a single alert immediately.
+     */
+    public function evaluateAlert(Alert $alert, AlertEngine $engine): JsonResponse
+    {
+        $alert->loadMissing('notificationProviders');
+        $result = $engine->evaluateAlert($alert);
+
+        return \response()->json($result);
+    }
+
+    /**
+     * Evaluate all enabled alerts using a background batch job.
+     */
+    public function evaluateAllAlerts(): JsonResponse
+    {
+        return \response()->json($this->evaluationBatch->startEvaluateAll());
+    }
+
+    /**
+     * Get evaluation batch status and progress.
+     */
+    public function evaluationStatus(string $evaluationId): JsonResponse
+    {
+        return \response()->json($this->evaluationBatch->getEvaluationStatus($evaluationId));
+    }
+
+    /**
      * Display the list of alerts.
      */
     public function index(): View
@@ -61,47 +117,17 @@ class AlertController extends Controller
     }
 
     /**
-     * Show the form to create a new alert.
+     * Retry a failed alert log delivery.
      */
-    public function create(): View
+    public function retryLog(AlertLog $log, AlertEngine $engine): RedirectResponse
     {
-        return \view('horizon.alerts.form', $this->alertUpsert->buildFormViewVariables(new Alert));
-    }
-
-    /**
-     * Store a new alert.
-     */
-    public function store(Request $request): RedirectResponse
-    {
-        $data = $this->alertUpsert->validateAlert($request);
-        $alert = Alert::create($data['alert']);
-        $alert->notificationProviders()->sync($data['provider_ids']);
+        if ($log->status === 'failed') {
+            $engine->retryAlertLog($log);
+        }
 
         return redirect()
-            ->route('horizon.alerts.index')
-            ->with('status', 'Alert created.');
-    }
-
-    /**
-     * Show the form to edit an existing alert.
-     */
-    public function edit(Alert $alert): View
-    {
-        return \view('horizon.alerts.form', $this->alertUpsert->buildFormViewVariables($alert));
-    }
-
-    /**
-     * Update an existing alert.
-     */
-    public function update(Request $request, Alert $alert): RedirectResponse
-    {
-        $data = $this->alertUpsert->validateAlert($request);
-        $alert->update($data['alert']);
-        $alert->notificationProviders()->sync($data['provider_ids']);
-
-        return redirect()
-            ->route('horizon.alerts.index')
-            ->with('status', 'Alert updated.');
+            ->route('horizon.alerts.show', [$log->alert_id])
+            ->with('status', 'Retry requested for alert delivery.');
     }
 
     /**
@@ -174,56 +200,30 @@ class AlertController extends Controller
     }
 
     /**
-     * Delete an alert.
+     * Store a new alert.
      */
-    public function destroy(Alert $alert): RedirectResponse
+    public function store(Request $request): RedirectResponse
     {
-        $name = $alert->name ?: ('Alert #'.$alert->id);
-        $alert->delete();
+        $data = $this->alertUpsert->validateAlert($request);
+        $alert = Alert::create($data['alert']);
+        $alert->notificationProviders()->sync($data['provider_ids']);
 
         return redirect()
             ->route('horizon.alerts.index')
-            ->with('status', "Alert $name deleted.");
+            ->with('status', 'Alert created.');
     }
 
     /**
-     * Retry a failed alert log delivery.
+     * Update an existing alert.
      */
-    public function retryLog(AlertLog $log, AlertEngine $engine): RedirectResponse
+    public function update(Request $request, Alert $alert): RedirectResponse
     {
-        if ($log->status === 'failed') {
-            $engine->retryAlertLog($log);
-        }
+        $data = $this->alertUpsert->validateAlert($request);
+        $alert->update($data['alert']);
+        $alert->notificationProviders()->sync($data['provider_ids']);
 
         return redirect()
-            ->route('horizon.alerts.show', [$log->alert_id])
-            ->with('status', 'Retry requested for alert delivery.');
-    }
-
-    /**
-     * Evaluate a single alert immediately.
-     */
-    public function evaluateAlert(Alert $alert, AlertEngine $engine): JsonResponse
-    {
-        $alert->loadMissing('notificationProviders');
-        $result = $engine->evaluateAlert($alert);
-
-        return \response()->json($result);
-    }
-
-    /**
-     * Evaluate all enabled alerts using a background batch job.
-     */
-    public function evaluateAllAlerts(): JsonResponse
-    {
-        return \response()->json($this->evaluationBatch->startEvaluateAll());
-    }
-
-    /**
-     * Get evaluation batch status and progress.
-     */
-    public function evaluationStatus(string $evaluationId): JsonResponse
-    {
-        return \response()->json($this->evaluationBatch->getEvaluationStatus($evaluationId));
+            ->route('horizon.alerts.index')
+            ->with('status', 'Alert updated.');
     }
 }

--- a/app/Http/Controllers/Horizon/JobActionController.php
+++ b/app/Http/Controllers/Horizon/JobActionController.php
@@ -35,34 +35,6 @@ class JobActionController extends Controller
     }
 
     /**
-     * Retry a job.
-     */
-    public function retry(Request $request): JsonResponse
-    {
-        $validated = $request->validate([
-            'uuid' => ['required', 'string'],
-            'service_id' => ['required', 'integer', 'exists:services,id'],
-        ]);
-        $uuid = $validated['uuid'];
-        $serviceId = $validated['service_id'];
-
-        $service = Service::find($serviceId);
-        if (! $service) {
-            return \response()->json(['message' => 'Service not found'], 404);
-        }
-
-        $result = $this->horizonApi->retryJob($service, $uuid);
-        if (! $result['success']) {
-            return \response()->json(
-                ['message' => $result['message'] ?? 'Horizon API request failed'],
-                $result['status'] ?? Response::HTTP_BAD_GATEWAY
-            );
-        }
-
-        return \response()->json(['message' => 'Retry requested']);
-    }
-
-    /**
      * List failed jobs for the retry modal (with filters).
      */
     public function failedList(Request $request): JsonResponse
@@ -164,6 +136,34 @@ class JobActionController extends Controller
         $returnData['meta']['total'] = $pageData['total'];
 
         return \response()->json($returnData);
+    }
+
+    /**
+     * Retry a job.
+     */
+    public function retry(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'uuid' => ['required', 'string'],
+            'service_id' => ['required', 'integer', 'exists:services,id'],
+        ]);
+        $uuid = $validated['uuid'];
+        $serviceId = $validated['service_id'];
+
+        $service = Service::find($serviceId);
+        if (! $service) {
+            return \response()->json(['message' => 'Service not found'], 404);
+        }
+
+        $result = $this->horizonApi->retryJob($service, $uuid);
+        if (! $result['success']) {
+            return \response()->json(
+                ['message' => $result['message'] ?? 'Horizon API request failed'],
+                $result['status'] ?? Response::HTTP_BAD_GATEWAY
+            );
+        }
+
+        return \response()->json(['message' => 'Retry requested']);
     }
 
     /**

--- a/app/Http/Controllers/Horizon/JobController.php
+++ b/app/Http/Controllers/Horizon/JobController.php
@@ -13,9 +13,9 @@ use Illuminate\Http\Request;
 class JobController extends Controller
 {
     /**
-     * The job list service.
+     * The Horizon API proxy service.
      */
-    private HorizonJobListService $jobList;
+    private HorizonApiProxyService $horizonApi;
 
     /**
      * The job detail service.
@@ -23,9 +23,9 @@ class JobController extends Controller
     private HorizonJobDetailService $jobDetail;
 
     /**
-     * The Horizon API proxy service.
+     * The job list service.
      */
-    private HorizonApiProxyService $horizonApi;
+    private HorizonJobListService $jobList;
 
     /**
      * The constructor.

--- a/app/Http/Controllers/Horizon/ProviderController.php
+++ b/app/Http/Controllers/Horizon/ProviderController.php
@@ -19,6 +19,26 @@ class ProviderController extends Controller
     }
 
     /**
+     * Delete a provider.
+     */
+    public function destroy(NotificationProvider $provider): RedirectResponse
+    {
+        $provider->delete();
+
+        return redirect()
+            ->route('horizon.settings', ['tab' => 'providers'])
+            ->with('status', 'Provider deleted.');
+    }
+
+    /**
+     * Show the form to edit an existing provider.
+     */
+    public function edit(NotificationProvider $provider): View
+    {
+        return $this->private__formView($provider);
+    }
+
+    /**
      * Store a new provider.
      */
     public function store(Request $request): RedirectResponse
@@ -32,14 +52,6 @@ class ProviderController extends Controller
     }
 
     /**
-     * Show the form to edit an existing provider.
-     */
-    public function edit(NotificationProvider $provider): View
-    {
-        return $this->private__formView($provider);
-    }
-
-    /**
      * Update an existing provider.
      */
     public function update(Request $request, NotificationProvider $provider): RedirectResponse
@@ -50,18 +62,6 @@ class ProviderController extends Controller
         return redirect()
             ->route('horizon.settings', ['tab' => 'providers'])
             ->with('status', 'Provider updated.');
-    }
-
-    /**
-     * Delete a provider.
-     */
-    public function destroy(NotificationProvider $provider): RedirectResponse
-    {
-        $provider->delete();
-
-        return redirect()
-            ->route('horizon.settings', ['tab' => 'providers'])
-            ->with('status', 'Provider deleted.');
     }
 
     /**

--- a/app/Http/Controllers/Horizon/ServiceController.php
+++ b/app/Http/Controllers/Horizon/ServiceController.php
@@ -14,6 +14,29 @@ use Illuminate\Http\Request;
 class ServiceController extends Controller
 {
     /**
+     * Delete a service.
+     */
+    public function destroy(Service $service): RedirectResponse
+    {
+        $service->delete();
+
+        return redirect()
+            ->route('horizon.services.index')
+            ->with('status', 'Service deleted.');
+    }
+
+    /**
+     * Edit an existing service.
+     */
+    public function edit(Service $service): View
+    {
+        return \view('horizon.services.edit', [
+            'service' => $service,
+            'header' => 'Edit service',
+        ]);
+    }
+
+    /**
      * Display the list of services and registration form.
      */
     public function index(HorizonApiProxyService $horizonApi, ServiceStatsAttachmentService $serviceStats): View
@@ -28,6 +51,19 @@ class ServiceController extends Controller
             'services' => $services,
             'header' => 'Services',
         ]);
+    }
+
+    /**
+     * Show the service dashboard.
+     */
+    public function show(Request $request, Service $service, HorizonApiProxyService $horizonApi, ServiceShowPageDataService $serviceShowPageData): View
+    {
+        $data = $serviceShowPageData->build($service, $request, $horizonApi);
+
+        return \view('horizon.services.show', \array_merge($data, [
+            'service' => $service,
+            'header' => $service->name,
+        ]));
     }
 
     /**
@@ -51,51 +87,6 @@ class ServiceController extends Controller
         return redirect()
             ->route('horizon.services.index')
             ->with('status', 'Service created.');
-    }
-
-    /**
-     * Edit an existing service.
-     */
-    public function edit(Service $service): View
-    {
-        return \view('horizon.services.edit', [
-            'service' => $service,
-            'header' => 'Edit service',
-        ]);
-    }
-
-    /**
-     * Update an existing service.
-     */
-    public function update(Request $request, Service $service): RedirectResponse
-    {
-        $validated = $request->validate([
-            'name' => 'required|string|max:255|unique:services,name,'.(int) $service->id,
-            'base_url' => 'required|url',
-            'public_url' => 'nullable|url',
-        ]);
-
-        $service->update([
-            'name' => $validated['name'],
-            'base_url' => \rtrim($validated['base_url'], '/'),
-            'public_url' => ! empty($validated['public_url']) ? \rtrim($validated['public_url'], '/') : null,
-        ]);
-
-        return redirect()
-            ->route('horizon.services.index')
-            ->with('status', 'Service updated.');
-    }
-
-    /**
-     * Delete a service.
-     */
-    public function destroy(Service $service): RedirectResponse
-    {
-        $service->delete();
-
-        return redirect()
-            ->route('horizon.services.index')
-            ->with('status', 'Service deleted.');
     }
 
     /**
@@ -132,15 +123,24 @@ class ServiceController extends Controller
     }
 
     /**
-     * Show the service dashboard.
+     * Update an existing service.
      */
-    public function show(Request $request, Service $service, HorizonApiProxyService $horizonApi, ServiceShowPageDataService $serviceShowPageData): View
+    public function update(Request $request, Service $service): RedirectResponse
     {
-        $data = $serviceShowPageData->build($service, $request, $horizonApi);
+        $validated = $request->validate([
+            'name' => 'required|string|max:255|unique:services,name,'.(int) $service->id,
+            'base_url' => 'required|url',
+            'public_url' => 'nullable|url',
+        ]);
 
-        return \view('horizon.services.show', \array_merge($data, [
-            'service' => $service,
-            'header' => $service->name,
-        ]));
+        $service->update([
+            'name' => $validated['name'],
+            'base_url' => \rtrim($validated['base_url'], '/'),
+            'public_url' => ! empty($validated['public_url']) ? \rtrim($validated['public_url'], '/') : null,
+        ]);
+
+        return redirect()
+            ->route('horizon.services.index')
+            ->with('status', 'Service updated.');
     }
 }

--- a/app/Http/Controllers/Stream/HorizonStreamsController.php
+++ b/app/Http/Controllers/Stream/HorizonStreamsController.php
@@ -21,19 +21,9 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 class HorizonStreamsController extends StreamController
 {
     /**
-     * The metrics dashboard data service.
-     */
-    private MetricsDashboardDataService $metricsDashboard;
-
-    /**
      * The dashboard data service.
      */
     private DashboardDataService $dashboardData;
-
-    /**
-     * The metrics service.
-     */
-    private HorizonMetricsService $metrics;
 
     /**
      * The horizon api proxy service.
@@ -41,14 +31,24 @@ class HorizonStreamsController extends StreamController
     private HorizonApiProxyService $horizonApi;
 
     /**
+     * The horizon job detail service.
+     */
+    private HorizonJobDetailService $jobDetail;
+
+    /**
      * The horizon job list service.
      */
     private HorizonJobListService $jobList;
 
     /**
-     * The horizon job detail service.
+     * The metrics service.
      */
-    private HorizonJobDetailService $jobDetail;
+    private HorizonMetricsService $metrics;
+
+    /**
+     * The metrics dashboard data service.
+     */
+    private MetricsDashboardDataService $metricsDashboard;
 
     /**
      * The service show page data service.
@@ -75,33 +75,14 @@ class HorizonStreamsController extends StreamController
         $this->serviceStats = $serviceStats;
     }
 
-    public function metrics(Request $request): StreamedResponse
+    public function alerts(): StreamedResponse
     {
-        $query = $request->getQueryString() ?? '';
-
-        return $this->runStream(fn (): ?string => $this->private__buildMetricsStreams($query));
+        return $this->runStream(fn (): ?string => $this->private__buildAlertsStreams());
     }
 
     public function dashboard(): StreamedResponse
     {
         return $this->runStream(fn (): ?string => $this->private__buildDashboardStreams());
-    }
-
-    public function queues(Request $request): StreamedResponse
-    {
-        $query = $request->getQueryString() ?? '';
-
-        return $this->runStream(fn (): ?string => $this->private__buildQueuesStreams($query));
-    }
-
-    public function serviceList(): StreamedResponse
-    {
-        return $this->runStream(fn (): ?string => $this->private__buildServicesStreams());
-    }
-
-    public function alerts(): StreamedResponse
-    {
-        return $this->runStream(fn (): ?string => $this->private__buildAlertsStreams());
     }
 
     public function jobs(Request $request): StreamedResponse
@@ -118,6 +99,25 @@ class HorizonStreamsController extends StreamController
         return $this->runStream(fn (): ?string => $this->private__buildJobShowStreams($job, $serviceId));
     }
 
+    public function metrics(Request $request): StreamedResponse
+    {
+        $query = $request->getQueryString() ?? '';
+
+        return $this->runStream(fn (): ?string => $this->private__buildMetricsStreams($query));
+    }
+
+    public function queues(Request $request): StreamedResponse
+    {
+        $query = $request->getQueryString() ?? '';
+
+        return $this->runStream(fn (): ?string => $this->private__buildQueuesStreams($query));
+    }
+
+    public function serviceList(): StreamedResponse
+    {
+        return $this->runStream(fn (): ?string => $this->private__buildServicesStreams());
+    }
+
     public function serviceShow(Request $request, Service $service): StreamedResponse
     {
         $query = $request->getQueryString() ?? '';
@@ -126,39 +126,20 @@ class HorizonStreamsController extends StreamController
     }
 
     // ------------------------------------------------------------------
-    //  Metrics
+    //  Alerts index
     // ------------------------------------------------------------------
 
-    private function private__buildMetricsStreams(string $query): ?string
+    private function private__buildAlertsStreams(): ?string
     {
-        $d = $this->metricsDashboard->build($this->private__parseServiceIdsFromQuery($query));
+        $alerts = Alert::query()
+            ->withCount('alertLogs')
+            ->withMax('alertLogs', 'sent_at')
+            ->orderByDesc('created_at')
+            ->get();
 
-        $updates = [
-            'metrics-value-jobs-minute' => e($d['jobsPastMinute'] ?? '—'),
-            'metrics-value-jobs-hour' => e($d['jobsPastHour'] ?? '—'),
-            'metrics-value-failed-seven' => e($d['failedPastSevenDays'] ?? '—'),
-            'metrics-workload-summary' => e($d['workloadSummary']),
-            'metrics-supervisors-summary' => e($d['supervisorsSummary']),
-        ];
+        $html = \view('horizon.alerts.partials.alert-tbody', ['alerts' => $alerts])->render();
 
-        $streams = [];
-        $this->private__pushStreamUpdates($streams, $updates);
-
-        $failureRateHtml = \view('horizon.metrics.partials.failure-rate-value', [
-            'failureRate24h' => $d['failureRate24h'],
-        ])->render();
-        $streams[] = $this->private__turboStreamTag('update', 'metrics-value-failure-rate', $failureRateHtml);
-
-        $chartJson = \json_encode($d['metricsChartData'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-        $streams[] = $this->private__turboStreamTag('replace', 'metrics-chart-data', '<script type="application/json" id="metrics-chart-data">'.$chartJson.'</script>');
-
-        $views = [
-            'metrics-workload-body' => ['view' => 'horizon.metrics.partials.workload-tbody', 'data' => ['workloadRows' => $d['workloadRows']]],
-            'metrics-supervisors-body' => ['view' => 'horizon.metrics.partials.supervisors-tbody', 'data' => ['supervisorsRows' => $d['supervisorsRows']]],
-        ];
-        $this->private__pushViewStreams($streams, $views, 'morph');
-
-        return \implode("\n", $streams);
+        return $this->private__turboStreamTag('update', 'turbo-tbody-horizon-alerts-list', $html, 'morph');
     }
 
     // ------------------------------------------------------------------
@@ -190,77 +171,6 @@ class HorizonStreamsController extends StreamController
         $this->private__pushViewStreams($streams, $views, 'morph');
 
         return \implode("\n", $streams);
-    }
-
-    // ------------------------------------------------------------------
-    //  Queues
-    // ------------------------------------------------------------------
-
-    private function private__buildQueuesStreams(string $query): ?string
-    {
-        $serviceFilterIds = $this->private__parseServiceIdsFromQuery($query, 'queue_services');
-        $queues = $this->metrics->buildQueuesCollectionForServiceFilter($serviceFilterIds);
-
-        $html = \view('horizon.queues.partials.queue-tbody', ['queues' => $queues])->render();
-
-        return $this->private__turboStreamTag('update', 'turbo-tbody-horizon-queue-list', $html, 'morph');
-    }
-
-    // ------------------------------------------------------------------
-    //  Services index
-    // ------------------------------------------------------------------
-
-    private function private__buildServicesStreams(): ?string
-    {
-        $services = Service::query()->orderBy('name')->get();
-        $this->serviceStats->attachHorizonStats($services, $this->horizonApi);
-
-        $html = \view('horizon.services.partials.service-tbody', ['services' => $services])->render();
-
-        return $this->private__turboStreamTag('update', 'turbo-tbody-horizon-service-list', $html, 'morph');
-    }
-
-    // ------------------------------------------------------------------
-    //  Alerts index
-    // ------------------------------------------------------------------
-
-    private function private__buildAlertsStreams(): ?string
-    {
-        $alerts = Alert::query()
-            ->withCount('alertLogs')
-            ->withMax('alertLogs', 'sent_at')
-            ->orderByDesc('created_at')
-            ->get();
-
-        $html = \view('horizon.alerts.partials.alert-tbody', ['alerts' => $alerts])->render();
-
-        return $this->private__turboStreamTag('update', 'turbo-tbody-horizon-alerts-list', $html, 'morph');
-    }
-
-    // ------------------------------------------------------------------
-    //  Jobs index
-    // ------------------------------------------------------------------
-
-    private function private__buildJobsIndexStreams(string $query): ?string
-    {
-        $url = \route('horizon.jobs.index', [], true);
-        if ($query !== '') {
-            $url .= "?$query";
-        }
-        $pageRequest = Request::create($url, 'GET');
-
-        $index = $this->jobList->buildAggregatedJobsIndexFromRequest($pageRequest);
-
-        return \implode("\n", $this->private__streamsForJobListSections(
-            [
-                'processing' => $index['processing'],
-                'processed' => $index['processed'],
-                'failed' => $index['failed'],
-            ],
-            'horizon-job-list',
-            true,
-            null,
-        ));
     }
 
     // ------------------------------------------------------------------
@@ -323,6 +233,82 @@ class HorizonStreamsController extends StreamController
     }
 
     // ------------------------------------------------------------------
+    //  Jobs index
+    // ------------------------------------------------------------------
+
+    private function private__buildJobsIndexStreams(string $query): ?string
+    {
+        $url = \route('horizon.jobs.index', [], true);
+        if ($query !== '') {
+            $url .= "?$query";
+        }
+        $pageRequest = Request::create($url, 'GET');
+
+        $index = $this->jobList->buildAggregatedJobsIndexFromRequest($pageRequest);
+
+        return \implode("\n", $this->private__streamsForJobListSections(
+            [
+                'processing' => $index['processing'],
+                'processed' => $index['processed'],
+                'failed' => $index['failed'],
+            ],
+            'horizon-job-list',
+            true,
+            null,
+        ));
+    }
+
+    // ------------------------------------------------------------------
+    //  Metrics
+    // ------------------------------------------------------------------
+
+    private function private__buildMetricsStreams(string $query): ?string
+    {
+        $d = $this->metricsDashboard->build($this->private__parseServiceIdsFromQuery($query));
+
+        $updates = [
+            'metrics-value-jobs-minute' => e($d['jobsPastMinute'] ?? '—'),
+            'metrics-value-jobs-hour' => e($d['jobsPastHour'] ?? '—'),
+            'metrics-value-failed-seven' => e($d['failedPastSevenDays'] ?? '—'),
+            'metrics-workload-summary' => e($d['workloadSummary']),
+            'metrics-supervisors-summary' => e($d['supervisorsSummary']),
+        ];
+
+        $streams = [];
+        $this->private__pushStreamUpdates($streams, $updates);
+
+        $failureRateHtml = \view('horizon.metrics.partials.failure-rate-value', [
+            'failureRate24h' => $d['failureRate24h'],
+        ])->render();
+        $streams[] = $this->private__turboStreamTag('update', 'metrics-value-failure-rate', $failureRateHtml);
+
+        $chartJson = \json_encode($d['metricsChartData'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $streams[] = $this->private__turboStreamTag('replace', 'metrics-chart-data', '<script type="application/json" id="metrics-chart-data">'.$chartJson.'</script>');
+
+        $views = [
+            'metrics-workload-body' => ['view' => 'horizon.metrics.partials.workload-tbody', 'data' => ['workloadRows' => $d['workloadRows']]],
+            'metrics-supervisors-body' => ['view' => 'horizon.metrics.partials.supervisors-tbody', 'data' => ['supervisorsRows' => $d['supervisorsRows']]],
+        ];
+        $this->private__pushViewStreams($streams, $views, 'morph');
+
+        return \implode("\n", $streams);
+    }
+
+    // ------------------------------------------------------------------
+    //  Queues
+    // ------------------------------------------------------------------
+
+    private function private__buildQueuesStreams(string $query): ?string
+    {
+        $serviceFilterIds = $this->private__parseServiceIdsFromQuery($query, 'queue_services');
+        $queues = $this->metrics->buildQueuesCollectionForServiceFilter($serviceFilterIds);
+
+        $html = \view('horizon.queues.partials.queue-tbody', ['queues' => $queues])->render();
+
+        return $this->private__turboStreamTag('update', 'turbo-tbody-horizon-queue-list', $html, 'morph');
+    }
+
+    // ------------------------------------------------------------------
     //  Service show
     // ------------------------------------------------------------------
 
@@ -373,6 +359,51 @@ class HorizonStreamsController extends StreamController
         return \implode("\n", $streams);
     }
 
+    // ------------------------------------------------------------------
+    //  Services index
+    // ------------------------------------------------------------------
+
+    private function private__buildServicesStreams(): ?string
+    {
+        $services = Service::query()->orderBy('name')->get();
+        $this->serviceStats->attachHorizonStats($services, $this->horizonApi);
+
+        $html = \view('horizon.services.partials.service-tbody', ['services' => $services])->render();
+
+        return $this->private__turboStreamTag('update', 'turbo-tbody-horizon-service-list', $html, 'morph');
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function private__parseServiceIdsFromQuery(string $query, string $key = 'service_id'): array
+    {
+        if ($query === '') {
+            return [];
+        }
+
+        \parse_str($query, $params);
+        $raw = $params[$key] ?? null;
+
+        return ServiceRequest::parseIds($raw);
+    }
+
+    private function private__pushStreamUpdates(array &$streams, array $updates, ?string $streamMethod = null): void
+    {
+        foreach ($updates as $target => $content) {
+            $streams[] = $this->private__turboStreamTag('update', $target, $content, $streamMethod);
+        }
+    }
+
+    private function private__pushViewStreams(array &$streams, array $views, ?string $streamMethod = null): void
+    {
+        $updates = [];
+        foreach ($views as $target => $viewData) {
+            $updates[$target] = \view($viewData['view'], $viewData['data'] ?? [])->render();
+        }
+        $this->private__pushStreamUpdates($streams, $updates, $streamMethod);
+    }
+
     /**
      * Turbo streams for the three job list section tbodies, badge counts, and pagination (no thead replace).
      *
@@ -414,36 +445,5 @@ class HorizonStreamsController extends StreamController
         }
 
         return "$open><template>$content</template></turbo-stream>";
-    }
-
-    private function private__pushStreamUpdates(array &$streams, array $updates, ?string $streamMethod = null): void
-    {
-        foreach ($updates as $target => $content) {
-            $streams[] = $this->private__turboStreamTag('update', $target, $content, $streamMethod);
-        }
-    }
-
-    private function private__pushViewStreams(array &$streams, array $views, ?string $streamMethod = null): void
-    {
-        $updates = [];
-        foreach ($views as $target => $viewData) {
-            $updates[$target] = \view($viewData['view'], $viewData['data'] ?? [])->render();
-        }
-        $this->private__pushStreamUpdates($streams, $updates, $streamMethod);
-    }
-
-    /**
-     * @return list<int>
-     */
-    private function private__parseServiceIdsFromQuery(string $query, string $key = 'service_id'): array
-    {
-        if ($query === '') {
-            return [];
-        }
-
-        \parse_str($query, $params);
-        $raw = $params[$key] ?? null;
-
-        return ServiceRequest::parseIds($raw);
     }
 }

--- a/app/Http/Controllers/StreamController.php
+++ b/app/Http/Controllers/StreamController.php
@@ -7,21 +7,6 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 abstract class StreamController extends Controller
 {
     /**
-     * Get the stream headers.
-     *
-     * @return array<string, string>
-     */
-    protected function streamHeaders(): array
-    {
-        return [
-            'Content-Type' => 'text/event-stream',
-            'Cache-Control' => 'no-cache, no-store, must-revalidate',
-            'Pragma' => 'no-cache',
-            'X-Accel-Buffering' => 'no',
-        ];
-    }
-
-    /**
      * Run a streaming SSE.
      *
      * The callback must return a Turbo Stream HTML string (one or more
@@ -71,5 +56,20 @@ abstract class StreamController extends Controller
                 \sleep($interval);
             }
         }, 200, $this->streamHeaders());
+    }
+
+    /**
+     * Get the stream headers.
+     *
+     * @return array<string, string>
+     */
+    protected function streamHeaders(): array
+    {
+        return [
+            'Content-Type' => 'text/event-stream',
+            'Cache-Control' => 'no-cache, no-store, must-revalidate',
+            'Pragma' => 'no-cache',
+            'X-Accel-Buffering' => 'no',
+        ];
     }
 }

--- a/app/Http/Requests/Horizon/ServiceRequest.php
+++ b/app/Http/Requests/Horizon/ServiceRequest.php
@@ -9,24 +9,23 @@ use Illuminate\Http\Request;
 class ServiceRequest extends FormRequest
 {
     /**
-     * Authorize the request.
-     */
-    public function authorize(): bool
-    {
-        return true;
-    }
-
-    /**
-     * Get the validation rules for the request.
+     * Read the first non-empty request/query value for the given keys (in order), then parse and restrict to existing services.
      *
-     * @return array<string, array<int, string>>
+     * @param  list<string>  $keys
+     * @return list<int>
      */
-    public function rules(): array
+    public static function existingIdsFromRequest(Request $request, array $keys): array
     {
-        return [
-            'service_id' => ['nullable', 'array'],
-            'service_id.*' => ['integer', 'exists:services,id'],
-        ];
+        $raw = self::private__firstRawValueForKeys($request, $keys);
+        $serviceIds = self::parseIds($raw);
+        if ($serviceIds === []) {
+            return [];
+        }
+
+        $existing = Service::query()->whereIn('id', $serviceIds)->pluck('id')->map(static fn ($id): int => (int) $id)->all();
+        \sort($existing);
+
+        return \array_values($existing);
     }
 
     /**
@@ -53,23 +52,24 @@ class ServiceRequest extends FormRequest
     }
 
     /**
-     * Read the first non-empty request/query value for the given keys (in order), then parse and restrict to existing services.
-     *
-     * @param  list<string>  $keys
-     * @return list<int>
+     * Authorize the request.
      */
-    public static function existingIdsFromRequest(Request $request, array $keys): array
+    public function authorize(): bool
     {
-        $raw = self::private__firstRawValueForKeys($request, $keys);
-        $serviceIds = self::parseIds($raw);
-        if ($serviceIds === []) {
-            return [];
-        }
+        return true;
+    }
 
-        $existing = Service::query()->whereIn('id', $serviceIds)->pluck('id')->map(static fn ($id): int => (int) $id)->all();
-        \sort($existing);
-
-        return \array_values($existing);
+    /**
+     * Get the validation rules for the request.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'service_id' => ['nullable', 'array'],
+            'service_id.*' => ['integer', 'exists:services,id'],
+        ];
     }
 
     /**

--- a/app/Jobs/EvaluateAlertJob.php
+++ b/app/Jobs/EvaluateAlertJob.php
@@ -123,11 +123,15 @@ class EvaluateAlertJob implements ShouldQueue
     }
 
     /**
-     * Get the cache key namespace.
+     * Cache the first error message.
      */
-    private function private__cacheKeyNamespace(): string
+    private function private__cacheFirstErrorMessage(string $message): void
     {
-        return "horizonhub.alert_evaluation_batches.$this->evaluationId";
+        $key = $this->private__cacheKeyNamespace().'.first_error_message';
+        if (Cache::get($key) !== null) {
+            return;
+        }
+        Cache::put($key, $message, self::CACHE_TTL_SECONDS);
     }
 
     /**
@@ -136,22 +140,6 @@ class EvaluateAlertJob implements ShouldQueue
     private function private__cacheKeyForAlertResult(): string
     {
         return $this->private__cacheKeyNamespace().'.results.'.$this->alertId;
-    }
-
-    /**
-     * Get the cache key for the evaluated count.
-     */
-    private function private__cacheKeyForEvaluatedCount(): string
-    {
-        return $this->private__cacheKeyNamespace().'.evaluated_count';
-    }
-
-    /**
-     * Get the cache key for the triggered count.
-     */
-    private function private__cacheKeyForTriggeredCount(): string
-    {
-        return $this->private__cacheKeyNamespace().'.triggered_count';
     }
 
     /**
@@ -171,14 +159,26 @@ class EvaluateAlertJob implements ShouldQueue
     }
 
     /**
-     * Cache the first error message.
+     * Get the cache key for the evaluated count.
      */
-    private function private__cacheFirstErrorMessage(string $message): void
+    private function private__cacheKeyForEvaluatedCount(): string
     {
-        $key = $this->private__cacheKeyNamespace().'.first_error_message';
-        if (Cache::get($key) !== null) {
-            return;
-        }
-        Cache::put($key, $message, self::CACHE_TTL_SECONDS);
+        return $this->private__cacheKeyNamespace().'.evaluated_count';
+    }
+
+    /**
+     * Get the cache key for the triggered count.
+     */
+    private function private__cacheKeyForTriggeredCount(): string
+    {
+        return $this->private__cacheKeyNamespace().'.triggered_count';
+    }
+
+    /**
+     * Get the cache key namespace.
+     */
+    private function private__cacheKeyNamespace(): string
+    {
+        return "horizonhub.alert_evaluation_batches.$this->evaluationId";
     }
 }

--- a/app/Mail/AlertBatchedMail.php
+++ b/app/Mail/AlertBatchedMail.php
@@ -27,14 +27,14 @@ class AlertBatchedMail extends Mailable
     public array $enrichedEvents;
 
     /**
-     * The service.
-     */
-    public ?Service $service;
-
-    /**
      * The mail subject.
      */
     public string $mailSubject;
+
+    /**
+     * The service.
+     */
+    public ?Service $service;
 
     /**
      * Total number of events (may exceed count of enrichedEvents when capped).
@@ -56,16 +56,6 @@ class AlertBatchedMail extends Mailable
     }
 
     /**
-     * Get the envelope for the email.
-     */
-    public function envelope(): Envelope
-    {
-        return new Envelope(
-            subject: $this->mailSubject
-        );
-    }
-
-    /**
      * Get the content for the email.
      */
     public function content(): Content
@@ -73,6 +63,16 @@ class AlertBatchedMail extends Mailable
         return new Content(
             view: 'emails.alert-batched',
             text: 'emails.alert-batched-text'
+        );
+    }
+
+    /**
+     * Get the envelope for the email.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: $this->mailSubject
         );
     }
 }

--- a/app/Models/Alert.php
+++ b/app/Models/Alert.php
@@ -8,24 +8,29 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Alert extends Model
 {
-    /**
-     * Cached service names grouped by service id.
-     *
-     * @var array<int, string>|null
-     */
-    private static ?array $cachedServiceNamesById = null;
+    public const RULE_AVG_EXECUTION_TIME = 'avg_execution_time';
 
     public const RULE_FAILURE_COUNT = 'failure_count';
 
-    public const RULE_AVG_EXECUTION_TIME = 'avg_execution_time';
+    public const RULE_HORIZON_OFFLINE = 'horizon_offline';
 
     public const RULE_QUEUE_BLOCKED = 'queue_blocked';
 
-    public const RULE_WORKER_OFFLINE = 'worker_offline';
-
     public const RULE_SUPERVISOR_OFFLINE = 'supervisor_offline';
 
-    public const RULE_HORIZON_OFFLINE = 'horizon_offline';
+    public const RULE_WORKER_OFFLINE = 'worker_offline';
+
+    /**
+     * The casts of the alert.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'threshold' => 'array',
+        'service_ids' => 'array',
+        'enabled' => 'boolean',
+        'email_interval_minutes' => 'integer',
+    ];
 
     /**
      * The fillable attributes of the alert.
@@ -44,16 +49,11 @@ class Alert extends Model
     ];
 
     /**
-     * The casts of the alert.
+     * Cached service names grouped by service id.
      *
-     * @var array<string, string>
+     * @var array<int, string>|null
      */
-    protected $casts = [
-        'threshold' => 'array',
-        'service_ids' => 'array',
-        'enabled' => 'boolean',
-        'email_interval_minutes' => 'integer',
-    ];
+    private static ?array $cachedServiceNamesById = null;
 
     /**
      * Get the alert logs of the alert.
@@ -61,6 +61,19 @@ class Alert extends Model
     public function alertLogs(): HasMany
     {
         return $this->hasMany(AlertLog::class);
+    }
+
+    /**
+     * Check whether this alert applies to the given service id.
+     */
+    public function appliesToServiceId(int $serviceId): bool
+    {
+        $scopedIds = $this->scopedServiceIds();
+        if ($scopedIds === []) {
+            return true;
+        }
+
+        return \in_array($serviceId, $scopedIds, true);
     }
 
     /**
@@ -122,18 +135,5 @@ class Alert extends Model
         }
 
         return $labels;
-    }
-
-    /**
-     * Check whether this alert applies to the given service id.
-     */
-    public function appliesToServiceId(int $serviceId): bool
-    {
-        $scopedIds = $this->scopedServiceIds();
-        if ($scopedIds === []) {
-            return true;
-        }
-
-        return \in_array($serviceId, $scopedIds, true);
     }
 }

--- a/app/Models/AlertLog.php
+++ b/app/Models/AlertLog.php
@@ -8,6 +8,16 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class AlertLog extends Model
 {
     /**
+     * The casts of the alert log.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'sent_at' => 'datetime',
+        'job_uuids' => 'array',
+    ];
+
+    /**
      * The fillable attributes of the alert log.
      *
      * @var array<int, string>
@@ -20,16 +30,6 @@ class AlertLog extends Model
         'status',
         'failure_message',
         'sent_at',
-    ];
-
-    /**
-     * The casts of the alert log.
-     *
-     * @var array<string, string>
-     */
-    protected $casts = [
-        'sent_at' => 'datetime',
-        'job_uuids' => 'array',
     ];
 
     /**

--- a/app/Models/NotificationProvider.php
+++ b/app/Models/NotificationProvider.php
@@ -12,23 +12,23 @@ class NotificationProvider extends Model
      *
      * @var string
      */
-    public const TYPE_SLACK = 'slack';
+    public const TYPE_EMAIL = 'email';
 
     /**
      * The type of the provider.
      *
      * @var string
      */
-    public const TYPE_EMAIL = 'email';
+    public const TYPE_SLACK = 'slack';
+
+    protected $casts = [
+        'config' => 'array',
+    ];
 
     protected $fillable = [
         'name',
         'type',
         'config',
-    ];
-
-    protected $casts = [
-        'config' => 'array',
     ];
 
     /**
@@ -38,14 +38,6 @@ class NotificationProvider extends Model
     {
         return $this->belongsToMany(Alert::class, 'alert_notification_provider')
             ->withTimestamps();
-    }
-
-    /**
-     * Get the webhook URL of the provider.
-     */
-    public function getWebhookUrl(): string
-    {
-        return (string) ($this->config['webhook_url'] ?? '');
     }
 
     /**
@@ -68,5 +60,13 @@ class NotificationProvider extends Model
         }
 
         return [];
+    }
+
+    /**
+     * Get the webhook URL of the provider.
+     */
+    public function getWebhookUrl(): string
+    {
+        return (string) ($this->config['webhook_url'] ?? '');
     }
 }

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -8,6 +8,15 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class Service extends Model
 {
     /**
+     * The casts of the service.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'last_seen_at' => 'datetime',
+    ];
+
+    /**
      * The fillable attributes of the service.
      *
      * @var array<int, string>
@@ -18,15 +27,6 @@ class Service extends Model
         'public_url',
         'status',
         'last_seen_at',
-    ];
-
-    /**
-     * The casts of the service.
-     *
-     * @var array<string, string>
-     */
-    protected $casts = [
-        'last_seen_at' => 'datetime',
     ];
 
     /**

--- a/app/Services/Alerts/AlertBatchStore.php
+++ b/app/Services/Alerts/AlertBatchStore.php
@@ -23,40 +23,6 @@ class AlertBatchStore
     private const SENT_AT_CACHE_PREFIX = 'horizonhub_alert_sent_at_';
 
     /**
-     * Get the pending events for the given alert.
-     *
-     * @param  Alert  $alert  The alert.
-     * @return array<int, array{service_id: int, job_uuid: string|null, triggered_at: string}>
-     */
-    public function getPending(Alert $alert): array
-    {
-        $key = self::PENDING_CACHE_PREFIX.$alert->id;
-        $raw = Cache::get($key);
-        if (! \is_array($raw)) {
-            return [];
-        }
-
-        return $raw;
-    }
-
-    /**
-     * Set the pending events for the given alert.
-     *
-     * @param  Alert  $alert  The alert.
-     * @param  array<int, array{service_id: int, job_uuid: string|null, triggered_at: string}>  $pending  The pending events.
-     */
-    public function setPending(Alert $alert, array $pending): void
-    {
-        $key = self::PENDING_CACHE_PREFIX.$alert->id;
-        if (empty($pending)) {
-            Cache::forget($key);
-
-            return;
-        }
-        Cache::put($key, $pending, \now()->addMinutes(config('horizonhub.alerts.pending_ttl_minutes')));
-    }
-
-    /**
      * Clear the pending events for the given alert.
      *
      * @param  Alert  $alert  The alert.
@@ -64,6 +30,20 @@ class AlertBatchStore
     public function clearPending(Alert $alert): void
     {
         $this->setPending($alert, []);
+    }
+
+    /**
+     * Get the interval minutes for the given alert.
+     *
+     * @param  Alert  $alert  The alert.
+     */
+    public function getIntervalMinutes(Alert $alert): int
+    {
+        if ($alert->email_interval_minutes !== null) {
+            return (int) $alert->email_interval_minutes;
+        }
+
+        return 0;
     }
 
     /**
@@ -83,6 +63,23 @@ class AlertBatchStore
     }
 
     /**
+     * Get the pending events for the given alert.
+     *
+     * @param  Alert  $alert  The alert.
+     * @return array<int, array{service_id: int, job_uuid: string|null, triggered_at: string}>
+     */
+    public function getPending(Alert $alert): array
+    {
+        $key = self::PENDING_CACHE_PREFIX.$alert->id;
+        $raw = Cache::get($key);
+        if (! \is_array($raw)) {
+            return [];
+        }
+
+        return $raw;
+    }
+
+    /**
      * Set the last sent at time for the given alert.
      *
      * @param  Alert  $alert  The alert.
@@ -96,17 +93,20 @@ class AlertBatchStore
     }
 
     /**
-     * Get the interval minutes for the given alert.
+     * Set the pending events for the given alert.
      *
      * @param  Alert  $alert  The alert.
+     * @param  array<int, array{service_id: int, job_uuid: string|null, triggered_at: string}>  $pending  The pending events.
      */
-    public function getIntervalMinutes(Alert $alert): int
+    public function setPending(Alert $alert, array $pending): void
     {
-        if ($alert->email_interval_minutes !== null) {
-            return (int) $alert->email_interval_minutes;
-        }
+        $key = self::PENDING_CACHE_PREFIX.$alert->id;
+        if (empty($pending)) {
+            Cache::forget($key);
 
-        return 0;
+            return;
+        }
+        Cache::put($key, $pending, \now()->addMinutes(config('horizonhub.alerts.pending_ttl_minutes')));
     }
 
     /**

--- a/app/Services/Alerts/AlertEngine.php
+++ b/app/Services/Alerts/AlertEngine.php
@@ -11,11 +11,6 @@ use Illuminate\Support\Facades\Log;
 class AlertEngine
 {
     /**
-     * The rule evaluator.
-     */
-    private AlertRuleEvaluator $ruleEvaluator;
-
-    /**
      * The batch store.
      */
     private AlertBatchStore $batchStore;
@@ -26,6 +21,11 @@ class AlertEngine
     private AlertNotificationDispatcher $notificationDispatcher;
 
     /**
+     * The rule evaluator.
+     */
+    private AlertRuleEvaluator $ruleEvaluator;
+
+    /**
      * Construct the alert engine.
      */
     public function __construct(AlertRuleEvaluator $ruleEvaluator, AlertBatchStore $batchStore, AlertNotificationDispatcher $notificationDispatcher)
@@ -33,30 +33,6 @@ class AlertEngine
         $this->ruleEvaluator = $ruleEvaluator;
         $this->batchStore = $batchStore;
         $this->notificationDispatcher = $notificationDispatcher;
-    }
-
-    /**
-     * Flush pending alerts.
-     */
-    public function flushPendingAlerts(): void
-    {
-        /** @var Collection<int, Alert> $alerts */
-        $alerts = Alert::where('enabled', true)
-            ->with('notificationProviders')
-            ->get();
-        foreach ($alerts as $alert) {
-            try {
-                $pending = $this->batchStore->getPending($alert);
-                if (empty($pending) || ! $this->batchStore->shouldSendNow($alert)) {
-                    continue;
-                }
-                $this->private__sendBatchedAlert($alert, $pending);
-                $this->batchStore->clearPending($alert);
-                $this->batchStore->setLastSentAt($alert);
-            } catch (\Throwable $e) {
-                Log::error('Horizon Hub: flush pending alert failed', ['alert_id' => $alert->id, 'error' => $e->getMessage()]);
-            }
-        }
     }
 
     /**
@@ -83,43 +59,6 @@ class AlertEngine
             $result = $this->ruleEvaluator->evaluateWithTriggeringJobs($alert, $serviceId, $jobUuid);
             if ($result['triggered']) {
                 $this->private__triggerAlert($alert, $serviceId, $jobUuid, $result['job_uuids']);
-            }
-        }
-    }
-
-    /**
-     * Evaluate the scheduled alerts.
-     */
-    public function evaluateScheduled(): void
-    {
-        $this->flushPendingAlerts();
-
-        /** @var Collection<int, Alert> $alerts */
-        $alerts = Alert::where('enabled', true)
-            ->with('notificationProviders')
-            ->get();
-        $services = Service::all();
-
-        foreach ($alerts as $alert) {
-            try {
-                $serviceIds = $alert->scopedServiceIds();
-                if ($serviceIds === []) {
-                    $serviceIds = $services->pluck('id')->all();
-                }
-                if (empty($serviceIds)) {
-                    Log::warning('Horizon Hub: no services to evaluate alert (add at least one service)', ['alert_id' => $alert->id]);
-
-                    continue;
-                }
-                foreach ($serviceIds as $serviceId) {
-                    $result = $this->ruleEvaluator->evaluateWithTriggeringJobs($alert, $serviceId, null);
-                    if ($result['triggered']) {
-                        $this->private__triggerAlert($alert, $serviceId, null, $result['job_uuids']);
-                        break;
-                    }
-                }
-            } catch (\Throwable $e) {
-                Log::error('Horizon Hub: evaluate scheduled alert failed', ['alert_id' => $alert->id, 'error' => $e->getMessage()]);
             }
         }
     }
@@ -225,6 +164,67 @@ class AlertEngine
     }
 
     /**
+     * Evaluate the scheduled alerts.
+     */
+    public function evaluateScheduled(): void
+    {
+        $this->flushPendingAlerts();
+
+        /** @var Collection<int, Alert> $alerts */
+        $alerts = Alert::where('enabled', true)
+            ->with('notificationProviders')
+            ->get();
+        $services = Service::all();
+
+        foreach ($alerts as $alert) {
+            try {
+                $serviceIds = $alert->scopedServiceIds();
+                if ($serviceIds === []) {
+                    $serviceIds = $services->pluck('id')->all();
+                }
+                if (empty($serviceIds)) {
+                    Log::warning('Horizon Hub: no services to evaluate alert (add at least one service)', ['alert_id' => $alert->id]);
+
+                    continue;
+                }
+                foreach ($serviceIds as $serviceId) {
+                    $result = $this->ruleEvaluator->evaluateWithTriggeringJobs($alert, $serviceId, null);
+                    if ($result['triggered']) {
+                        $this->private__triggerAlert($alert, $serviceId, null, $result['job_uuids']);
+                        break;
+                    }
+                }
+            } catch (\Throwable $e) {
+                Log::error('Horizon Hub: evaluate scheduled alert failed', ['alert_id' => $alert->id, 'error' => $e->getMessage()]);
+            }
+        }
+    }
+
+    /**
+     * Flush pending alerts.
+     */
+    public function flushPendingAlerts(): void
+    {
+        /** @var Collection<int, Alert> $alerts */
+        $alerts = Alert::where('enabled', true)
+            ->with('notificationProviders')
+            ->get();
+        foreach ($alerts as $alert) {
+            try {
+                $pending = $this->batchStore->getPending($alert);
+                if (empty($pending) || ! $this->batchStore->shouldSendNow($alert)) {
+                    continue;
+                }
+                $this->private__sendBatchedAlert($alert, $pending);
+                $this->batchStore->clearPending($alert);
+                $this->batchStore->setLastSentAt($alert);
+            } catch (\Throwable $e) {
+                Log::error('Horizon Hub: flush pending alert failed', ['alert_id' => $alert->id, 'error' => $e->getMessage()]);
+            }
+        }
+    }
+
+    /**
      * Retry the alert log.
      *
      * @param  AlertLog  $log  The alert log.
@@ -252,32 +252,6 @@ class AlertEngine
         ]);
 
         $this->notificationDispatcher->dispatch($alert, $events, $newLog);
-    }
-
-    /**
-     * Should evaluate the alert.
-     *
-     * @param  Alert  $alert  The alert.
-     * @param  string  $eventType  The event type.
-     */
-    private function private__shouldEvaluate(Alert $alert, string $eventType): bool
-    {
-        if ($alert->rule_type === Alert::RULE_FAILURE_COUNT && $eventType !== 'JobFailed') {
-            return false;
-        }
-        if ($alert->rule_type === Alert::RULE_AVG_EXECUTION_TIME) {
-            return \in_array($eventType, ['JobProcessed', 'JobCompleted'], true);
-        }
-        if (\in_array($alert->rule_type, [
-            Alert::RULE_QUEUE_BLOCKED,
-            Alert::RULE_WORKER_OFFLINE,
-            Alert::RULE_SUPERVISOR_OFFLINE,
-            Alert::RULE_HORIZON_OFFLINE,
-        ], true)) {
-            return false;
-        }
-
-        return true;
     }
 
     /**
@@ -314,6 +288,56 @@ class AlertEngine
         }
 
         return $events;
+    }
+
+    /**
+     * Send the batched alert.
+     *
+     * @param  Alert  $alert  The alert.
+     * @param  array<int, array{service_id: int, job_uuid: string|null, triggered_at: string}>  $events
+     */
+    private function private__sendBatchedAlert(Alert $alert, array $events): void
+    {
+        $first = $events[0];
+        $serviceId = (int) $first['service_id'];
+        $jobUuids = \array_values(\array_filter(\array_column($events, 'job_uuid')));
+
+        $log = AlertLog::create([
+            'alert_id' => $alert->id,
+            'service_id' => $serviceId,
+            'trigger_count' => \count($events),
+            'job_uuids' => $jobUuids ?: null,
+            'status' => 'sent',
+            'sent_at' => \now(),
+        ]);
+
+        $this->notificationDispatcher->dispatch($alert, $events, $log);
+    }
+
+    /**
+     * Should evaluate the alert.
+     *
+     * @param  Alert  $alert  The alert.
+     * @param  string  $eventType  The event type.
+     */
+    private function private__shouldEvaluate(Alert $alert, string $eventType): bool
+    {
+        if ($alert->rule_type === Alert::RULE_FAILURE_COUNT && $eventType !== 'JobFailed') {
+            return false;
+        }
+        if ($alert->rule_type === Alert::RULE_AVG_EXECUTION_TIME) {
+            return \in_array($eventType, ['JobProcessed', 'JobCompleted'], true);
+        }
+        if (\in_array($alert->rule_type, [
+            Alert::RULE_QUEUE_BLOCKED,
+            Alert::RULE_WORKER_OFFLINE,
+            Alert::RULE_SUPERVISOR_OFFLINE,
+            Alert::RULE_HORIZON_OFFLINE,
+        ], true)) {
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -356,29 +380,5 @@ class AlertEngine
         $this->private__sendBatchedAlert($alert, $pending);
         $this->batchStore->clearPending($alert);
         $this->batchStore->setLastSentAt($alert);
-    }
-
-    /**
-     * Send the batched alert.
-     *
-     * @param  Alert  $alert  The alert.
-     * @param  array<int, array{service_id: int, job_uuid: string|null, triggered_at: string}>  $events
-     */
-    private function private__sendBatchedAlert(Alert $alert, array $events): void
-    {
-        $first = $events[0];
-        $serviceId = (int) $first['service_id'];
-        $jobUuids = \array_values(\array_filter(\array_column($events, 'job_uuid')));
-
-        $log = AlertLog::create([
-            'alert_id' => $alert->id,
-            'service_id' => $serviceId,
-            'trigger_count' => \count($events),
-            'job_uuids' => $jobUuids ?: null,
-            'status' => 'sent',
-            'sent_at' => \now(),
-        ]);
-
-        $this->notificationDispatcher->dispatch($alert, $events, $log);
     }
 }

--- a/app/Services/Alerts/AlertEvaluationBatchService.php
+++ b/app/Services/Alerts/AlertEvaluationBatchService.php
@@ -12,6 +12,38 @@ use Illuminate\Support\Str;
 class AlertEvaluationBatchService
 {
     /**
+     * Get the evaluation status.
+     *
+     * @param  string  $evaluationId  The evaluation ID.
+     * @return array<string, mixed>
+     */
+    public function getEvaluationStatus(string $evaluationId): array
+    {
+        $namespace = "horizonhub.alert_evaluation_batches.$evaluationId";
+
+        $status = (string) (Cache::get("$namespace.status") ?? 'running');
+        $totalAlerts = (int) (Cache::get("$namespace.total_alerts") ?? 0);
+        $evaluatedCount = (int) (Cache::get("$namespace.evaluated_count") ?? 0);
+        $triggeredCount = (int) (Cache::get("$namespace.triggered_count") ?? 0);
+        $deliveredCount = (int) (Cache::get("$namespace.delivered_count") ?? 0);
+        $errorCount = (int) (Cache::get("$namespace.error_count") ?? 0);
+        $firstErrorMessage = Cache::get("$namespace.first_error_message");
+        $errorMessage = Cache::get("$namespace.error_message");
+
+        return [
+            'evaluation_id' => $evaluationId,
+            'status' => $status,
+            'total_alerts' => $totalAlerts,
+            'evaluated_count' => $evaluatedCount,
+            'triggered_count' => $triggeredCount,
+            'delivered_count' => $deliveredCount,
+            'error_count' => $errorCount,
+            'first_error_message' => \is_string($firstErrorMessage) ? $firstErrorMessage : null,
+            'error_message' => \is_string($errorMessage) ? $errorMessage : null,
+        ];
+    }
+
+    /**
      * Start evaluating all alerts.
      *
      * @return array{evaluation_id: string, status: string, total_alerts: int}
@@ -69,38 +101,6 @@ class AlertEvaluationBatchService
             'evaluation_id' => $evaluationId,
             'status' => 'running',
             'total_alerts' => $total,
-        ];
-    }
-
-    /**
-     * Get the evaluation status.
-     *
-     * @param  string  $evaluationId  The evaluation ID.
-     * @return array<string, mixed>
-     */
-    public function getEvaluationStatus(string $evaluationId): array
-    {
-        $namespace = "horizonhub.alert_evaluation_batches.$evaluationId";
-
-        $status = (string) (Cache::get("$namespace.status") ?? 'running');
-        $totalAlerts = (int) (Cache::get("$namespace.total_alerts") ?? 0);
-        $evaluatedCount = (int) (Cache::get("$namespace.evaluated_count") ?? 0);
-        $triggeredCount = (int) (Cache::get("$namespace.triggered_count") ?? 0);
-        $deliveredCount = (int) (Cache::get("$namespace.delivered_count") ?? 0);
-        $errorCount = (int) (Cache::get("$namespace.error_count") ?? 0);
-        $firstErrorMessage = Cache::get("$namespace.first_error_message");
-        $errorMessage = Cache::get("$namespace.error_message");
-
-        return [
-            'evaluation_id' => $evaluationId,
-            'status' => $status,
-            'total_alerts' => $totalAlerts,
-            'evaluated_count' => $evaluatedCount,
-            'triggered_count' => $triggeredCount,
-            'delivered_count' => $deliveredCount,
-            'error_count' => $errorCount,
-            'first_error_message' => \is_string($firstErrorMessage) ? $firstErrorMessage : null,
-            'error_message' => \is_string($errorMessage) ? $errorMessage : null,
         ];
     }
 }

--- a/app/Services/Alerts/AlertUpsertService.php
+++ b/app/Services/Alerts/AlertUpsertService.php
@@ -48,6 +48,51 @@ class AlertUpsertService
     }
 
     /**
+     * Merge the job type into the patterns.
+     *
+     * @param  list<string>  $patterns  The patterns.
+     * @param  string|null  $jobType  The job type.
+     * @return list<string>
+     */
+    public function mergeJobTypeIntoPatterns(array $patterns, ?string $jobType): array
+    {
+        $jt = $jobType !== null ? \trim($jobType) : '';
+        if ($jt === '' || \in_array($jt, $patterns, true)) {
+            return $patterns;
+        }
+        $merged = $patterns;
+        $merged[] = $jt;
+
+        return \array_slice(\array_values(\array_unique($merged)), 0, self::ALERT_PATTERN_LINES_MAX);
+    }
+
+    /**
+     * Sanitize the pattern array.
+     *
+     * @param  mixed  $raw  The raw value to sanitize.
+     * @return list<string>
+     */
+    public function sanitizePatternArray(mixed $raw): array
+    {
+        if (! \is_array($raw)) {
+            return [];
+        }
+        $out = [];
+        foreach ($raw as $v) {
+            if (! \is_string($v)) {
+                continue;
+            }
+            $t = \trim($v);
+            if ($t !== '') {
+                $out[] = $t;
+            }
+        }
+        $out = \array_values(\array_unique($out));
+
+        return \array_slice($out, 0, self::ALERT_PATTERN_LINES_MAX);
+    }
+
+    /**
      * Validate the alert.
      *
      * @param  Request  $request  The request.
@@ -182,50 +227,5 @@ class AlertUpsertService
             'alert' => $alertData,
             'provider_ids' => $validated['provider_ids'],
         ];
-    }
-
-    /**
-     * Sanitize the pattern array.
-     *
-     * @param  mixed  $raw  The raw value to sanitize.
-     * @return list<string>
-     */
-    public function sanitizePatternArray(mixed $raw): array
-    {
-        if (! \is_array($raw)) {
-            return [];
-        }
-        $out = [];
-        foreach ($raw as $v) {
-            if (! \is_string($v)) {
-                continue;
-            }
-            $t = \trim($v);
-            if ($t !== '') {
-                $out[] = $t;
-            }
-        }
-        $out = \array_values(\array_unique($out));
-
-        return \array_slice($out, 0, self::ALERT_PATTERN_LINES_MAX);
-    }
-
-    /**
-     * Merge the job type into the patterns.
-     *
-     * @param  list<string>  $patterns  The patterns.
-     * @param  string|null  $jobType  The job type.
-     * @return list<string>
-     */
-    public function mergeJobTypeIntoPatterns(array $patterns, ?string $jobType): array
-    {
-        $jt = $jobType !== null ? \trim($jobType) : '';
-        if ($jt === '' || \in_array($jt, $patterns, true)) {
-            return $patterns;
-        }
-        $merged = $patterns;
-        $merged[] = $jt;
-
-        return \array_slice(\array_values(\array_unique($merged)), 0, self::ALERT_PATTERN_LINES_MAX);
     }
 }

--- a/app/Services/Alerts/Rules/AlertRuleEvaluationSupport.php
+++ b/app/Services/Alerts/Rules/AlertRuleEvaluationSupport.php
@@ -29,6 +29,114 @@ final class AlertRuleEvaluationSupport
     }
 
     /**
+     * Collect the triggering job UUIDs.
+     *
+     * @param  Collection<int, array<string, mixed>>  $jobs
+     * @return array<int, string>
+     */
+    public function collectTriggeringJobUuids(Collection $jobs): array
+    {
+        return $jobs->take(self::MAX_TRIGGERING_JOB_UUIDS)
+            ->map(function ($job) {
+                $id = $job['id'] ?? null;
+
+                return $id !== null && $id !== '' ? (string) $id : null;
+            })
+            ->filter()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Check if the completed job row matches the alert.
+     *
+     * @param  Alert  $alert  The alert.
+     * @param  array<string, mixed>  $job  The job.
+     */
+    public function completedJobRowMatches(Alert $alert, array $job): bool
+    {
+        return $this->jobMatchesQueuePatterns($alert, $job)
+            && $this->private__jobMatchesJobPatterns($alert, $job);
+    }
+
+    /**
+     * Check if the failed job row matches the alert.
+     *
+     * @param  Alert  $alert  The alert.
+     * @param  array<string, mixed>  $job  The job.
+     */
+    public function failedJobRowMatches(Alert $alert, array $job): bool
+    {
+        return $this->jobMatchesQueuePatterns($alert, $job)
+            && $this->private__jobMatchesJobPatterns($alert, $job);
+    }
+
+    /**
+     * Filter the failed jobs in the window.
+     *
+     * @param  Collection<int, mixed>  $jobs
+     * @param  Carbon  $cutoff  The cutoff time.
+     * @return Collection<int, array<string, mixed>>
+     */
+    public function filterFailedJobsInWindow(Collection $jobs, Carbon $cutoff): Collection
+    {
+        return $jobs->filter(function ($job) use ($cutoff) {
+            if (! \is_array($job)) {
+                return false;
+            }
+            $failedAt = $this->private__parseFailedAt($job['failed_at'] ?? null);
+
+            return $failedAt !== null && $failedAt->gte($cutoff);
+        });
+    }
+
+    /**
+     * Check if the job matches the queue patterns.
+     *
+     * @param  array<string, mixed>  $job
+     */
+    public function jobMatchesQueuePatterns(Alert $alert, array $job): bool
+    {
+        $patterns = $this->resolveQueuePatterns($alert);
+        if ($patterns === []) {
+            return true;
+        }
+        $queue = (string) ($job['queue'] ?? '');
+
+        foreach ($patterns as $pattern) {
+            if ($queue === (string) $pattern) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Find the matching failed jobs in the window.
+     *
+     * @param  Alert  $alert  The alert.
+     * @param  Service  $service  The service.
+     * @param  Carbon  $cutoff  The cutoff time.
+     * @return Collection<int, array<string, mixed>>
+     */
+    public function matchingFailedJobsInWindow(Alert $alert, Service $service, Carbon $cutoff): Collection
+    {
+        $response = $this->horizonApi->getFailedJobs($service, ['starting_at' => 0]);
+        $data = $response['data'] ?? null;
+        if (! ($response['success'] ?? false) || ! \is_array($data)) {
+            return collect();
+        }
+        $jobs = collect($data['jobs'] ?? []);
+
+        return $this->filterFailedJobsInWindow($jobs, $cutoff)
+            ->filter(function ($job) use ($alert) {
+                return \is_array($job) && $this->failedJobRowMatches($alert, $job);
+            })
+            ->values();
+    }
+
+    /**
      * Resolve the job patterns from the alert threshold.
      *
      * @param  Alert  $alert  The alert.
@@ -87,20 +195,20 @@ final class AlertRuleEvaluationSupport
     }
 
     /**
-     * Check if the job matches the queue patterns.
+     * Check if the job matches the job patterns.
      *
-     * @param  array<string, mixed>  $job
+     * @param  Alert  $alert  The alert.
+     * @param  array<string, mixed>  $job  The job.
      */
-    public function jobMatchesQueuePatterns(Alert $alert, array $job): bool
+    private function private__jobMatchesJobPatterns(Alert $alert, array $job): bool
     {
-        $patterns = $this->resolveQueuePatterns($alert);
+        $patterns = $this->resolveJobPatterns($alert);
         if ($patterns === []) {
             return true;
         }
-        $queue = (string) ($job['queue'] ?? '');
-
+        $haystack = $this->private__jobPayloadHaystack($job);
         foreach ($patterns as $pattern) {
-            if ($queue === (string) $pattern) {
+            if ($pattern !== '' && \str_contains($haystack, $pattern)) {
                 return true;
             }
         }
@@ -109,89 +217,20 @@ final class AlertRuleEvaluationSupport
     }
 
     /**
-     * Check if the failed job row matches the alert.
+     * Get the job payload haystack.
      *
-     * @param  Alert  $alert  The alert.
      * @param  array<string, mixed>  $job  The job.
      */
-    public function failedJobRowMatches(Alert $alert, array $job): bool
+    private function private__jobPayloadHaystack(array $job): string
     {
-        return $this->jobMatchesQueuePatterns($alert, $job)
-            && $this->private__jobMatchesJobPatterns($alert, $job);
-    }
-
-    /**
-     * Check if the completed job row matches the alert.
-     *
-     * @param  Alert  $alert  The alert.
-     * @param  array<string, mixed>  $job  The job.
-     */
-    public function completedJobRowMatches(Alert $alert, array $job): bool
-    {
-        return $this->jobMatchesQueuePatterns($alert, $job)
-            && $this->private__jobMatchesJobPatterns($alert, $job);
-    }
-
-    /**
-     * Filter the failed jobs in the window.
-     *
-     * @param  Collection<int, mixed>  $jobs
-     * @param  Carbon  $cutoff  The cutoff time.
-     * @return Collection<int, array<string, mixed>>
-     */
-    public function filterFailedJobsInWindow(Collection $jobs, Carbon $cutoff): Collection
-    {
-        return $jobs->filter(function ($job) use ($cutoff) {
-            if (! \is_array($job)) {
-                return false;
-            }
-            $failedAt = $this->private__parseFailedAt($job['failed_at'] ?? null);
-
-            return $failedAt !== null && $failedAt->gte($cutoff);
-        });
-    }
-
-    /**
-     * Find the matching failed jobs in the window.
-     *
-     * @param  Alert  $alert  The alert.
-     * @param  Service  $service  The service.
-     * @param  Carbon  $cutoff  The cutoff time.
-     * @return Collection<int, array<string, mixed>>
-     */
-    public function matchingFailedJobsInWindow(Alert $alert, Service $service, Carbon $cutoff): Collection
-    {
-        $response = $this->horizonApi->getFailedJobs($service, ['starting_at' => 0]);
-        $data = $response['data'] ?? null;
-        if (! ($response['success'] ?? false) || ! \is_array($data)) {
-            return collect();
+        $payload = $job['payload'] ?? [];
+        if (! \is_array($payload)) {
+            $payload = [];
         }
-        $jobs = collect($data['jobs'] ?? []);
+        $displayName = $payload['displayName'] ?? null;
+        $rawJob = $payload['job'] ?? null;
 
-        return $this->filterFailedJobsInWindow($jobs, $cutoff)
-            ->filter(function ($job) use ($alert) {
-                return \is_array($job) && $this->failedJobRowMatches($alert, $job);
-            })
-            ->values();
-    }
-
-    /**
-     * Collect the triggering job UUIDs.
-     *
-     * @param  Collection<int, array<string, mixed>>  $jobs
-     * @return array<int, string>
-     */
-    public function collectTriggeringJobUuids(Collection $jobs): array
-    {
-        return $jobs->take(self::MAX_TRIGGERING_JOB_UUIDS)
-            ->map(function ($job) {
-                $id = $job['id'] ?? null;
-
-                return $id !== null && $id !== '' ? (string) $id : null;
-            })
-            ->filter()
-            ->values()
-            ->all();
+        return (string) ($displayName ?? $rawJob ?? '');
     }
 
     /**
@@ -222,44 +261,5 @@ final class AlertRuleEvaluationSupport
         }
 
         return null;
-    }
-
-    /**
-     * Get the job payload haystack.
-     *
-     * @param  array<string, mixed>  $job  The job.
-     */
-    private function private__jobPayloadHaystack(array $job): string
-    {
-        $payload = $job['payload'] ?? [];
-        if (! \is_array($payload)) {
-            $payload = [];
-        }
-        $displayName = $payload['displayName'] ?? null;
-        $rawJob = $payload['job'] ?? null;
-
-        return (string) ($displayName ?? $rawJob ?? '');
-    }
-
-    /**
-     * Check if the job matches the job patterns.
-     *
-     * @param  Alert  $alert  The alert.
-     * @param  array<string, mixed>  $job  The job.
-     */
-    private function private__jobMatchesJobPatterns(Alert $alert, array $job): bool
-    {
-        $patterns = $this->resolveJobPatterns($alert);
-        if ($patterns === []) {
-            return true;
-        }
-        $haystack = $this->private__jobPayloadHaystack($job);
-        foreach ($patterns as $pattern) {
-            if ($pattern !== '' && \str_contains($haystack, $pattern)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/app/Services/Alerts/Rules/AlertRuleStrategyRegistry.php
+++ b/app/Services/Alerts/Rules/AlertRuleStrategyRegistry.php
@@ -15,16 +15,16 @@ use App\Services\Alerts\Rules\Strategies\WorkerOfflineAlertRuleStrategy;
 final class AlertRuleStrategyRegistry
 {
     /**
+     * The null strategy.
+     */
+    private NullAlertRuleStrategy $nullStrategy;
+
+    /**
      * The strategies.
      *
      * @var array<string, AlertRuleStrategyInterface>
      */
     private array $strategies;
-
-    /**
-     * The null strategy.
-     */
-    private NullAlertRuleStrategy $nullStrategy;
 
     /**
      * Construct the strategy registry.

--- a/app/Services/Alerts/Rules/Strategies/AvgExecutionTimeAlertRuleStrategy.php
+++ b/app/Services/Alerts/Rules/Strategies/AvgExecutionTimeAlertRuleStrategy.php
@@ -12,14 +12,14 @@ use Carbon\Carbon;
 final class AvgExecutionTimeAlertRuleStrategy implements AlertRuleStrategyInterface
 {
     /**
-     * The evaluation support.
-     */
-    private AlertRuleEvaluationSupport $support;
-
-    /**
      * The Horizon API proxy service.
      */
     private HorizonApiProxyService $horizonApi;
+
+    /**
+     * The evaluation support.
+     */
+    private AlertRuleEvaluationSupport $support;
 
     /**
      * Construct the strategy.

--- a/app/Services/Alerts/Rules/Strategies/FailureCountAlertRuleStrategy.php
+++ b/app/Services/Alerts/Rules/Strategies/FailureCountAlertRuleStrategy.php
@@ -11,14 +11,14 @@ use App\Services\Horizon\HorizonApiProxyService;
 final class FailureCountAlertRuleStrategy implements AlertRuleStrategyInterface
 {
     /**
-     * The evaluation support.
-     */
-    private AlertRuleEvaluationSupport $support;
-
-    /**
      * The Horizon API proxy service.
      */
     private HorizonApiProxyService $horizonApi;
+
+    /**
+     * The evaluation support.
+     */
+    private AlertRuleEvaluationSupport $support;
 
     /**
      * Construct the strategy.

--- a/app/Services/Alerts/Rules/Strategies/QueueBlockedAlertRuleStrategy.php
+++ b/app/Services/Alerts/Rules/Strategies/QueueBlockedAlertRuleStrategy.php
@@ -12,14 +12,14 @@ use Carbon\Carbon;
 final class QueueBlockedAlertRuleStrategy implements AlertRuleStrategyInterface
 {
     /**
-     * The evaluation support.
-     */
-    private AlertRuleEvaluationSupport $support;
-
-    /**
      * The Horizon API proxy service.
      */
     private HorizonApiProxyService $horizonApi;
+
+    /**
+     * The evaluation support.
+     */
+    private AlertRuleEvaluationSupport $support;
 
     /**
      * Construct the strategy.

--- a/app/Services/Horizon/HorizonApiProxyService.php
+++ b/app/Services/Horizon/HorizonApiProxyService.php
@@ -14,77 +14,17 @@ use Illuminate\Support\Facades\Log;
 class HorizonApiProxyService
 {
     /**
-     * Retry a job through the Horizon HTTP API.
+     * Get completed jobs from the Horizon HTTP API for a service.
      *
      * @param  Service  $service  The service.
-     * @param  string  $jobUuid  The job UUID.
-     * @return array{success: bool, message?: string, status?: int}
-     */
-    public function retryJob(Service $service, string $jobUuid): array
-    {
-        $relativePath = \str_replace('{id}', $jobUuid, (string) config('horizonhub.horizon_paths.retry'));
-
-        return $this->private__call($service, $relativePath, 'post', true);
-    }
-
-    /**
-     * Test connectivity with the Horizon HTTP API for a service.
-     *
-     * @param  Service  $service  The service.
-     * @return array{success: bool, message?: string, status?: int}
-     */
-    public function ping(Service $service): array
-    {
-        $relativePath = (string) config('horizonhub.horizon_paths.ping');
-
-        return $this->private__call($service, $relativePath, 'get');
-    }
-
-    /**
-     * Get the queue workload from the Horizon HTTP API for a service.
-     *
-     * @param  Service  $service  The service.
+     * @param  array<string, mixed>  $query
      * @return array{success: bool, message?: string, status?: int, data?: array}
      */
-    public function getWorkload(Service $service): array
+    public function getCompletedJobs(Service $service, array $query = []): array
     {
-        $relativePath = (string) config('horizonhub.horizon_paths.workload');
+        $path = (string) config('horizonhub.horizon_paths.completed_jobs');
 
-        $result = $this->private__call($service, $relativePath, 'get');
-        if (! ($result['success'] ?? false) && \in_array($result['status'] ?? 0, [401, 403], true)) {
-            $result = $this->private__call($service, $relativePath, 'get', true);
-        }
-
-        return $result;
-    }
-
-    /**
-     * Get high-level dashboard statistics (including jobs per minute and recent jobs)
-     * from the Horizon HTTP API for a service.
-     *
-     * This proxies the Horizon `/stats` endpoint and returns its decoded payload.
-     *
-     * @param  Service  $service  The service.
-     * @return array{success: bool, message?: string, status?: int, data?: array}
-     */
-    public function getStats(Service $service): array
-    {
-        $relativePath = (string) config('horizonhub.horizon_paths.ping');
-
-        return $this->private__call($service, $relativePath, 'get');
-    }
-
-    /**
-     * Get Horizon masters (and their supervisors) from the Horizon HTTP API for a service.
-     *
-     * @param  Service  $service  The service.
-     * @return array{success: bool, message?: string, status?: int, data?: array}
-     */
-    public function getMasters(Service $service): array
-    {
-        $relativePath = (string) config('horizonhub.horizon_paths.masters');
-
-        return $this->private__call($service, $relativePath, 'get');
+        return $this->private__call($service, "$path?".\http_build_query($this->private__buildJobListQuery($query)), 'get');
     }
 
     /**
@@ -116,17 +56,16 @@ class HorizonApiProxyService
     }
 
     /**
-     * Get completed jobs from the Horizon HTTP API for a service.
+     * Get Horizon masters (and their supervisors) from the Horizon HTTP API for a service.
      *
      * @param  Service  $service  The service.
-     * @param  array<string, mixed>  $query
      * @return array{success: bool, message?: string, status?: int, data?: array}
      */
-    public function getCompletedJobs(Service $service, array $query = []): array
+    public function getMasters(Service $service): array
     {
-        $path = (string) config('horizonhub.horizon_paths.completed_jobs');
+        $relativePath = (string) config('horizonhub.horizon_paths.masters');
 
-        return $this->private__call($service, "$path?".\http_build_query($this->private__buildJobListQuery($query)), 'get');
+        return $this->private__call($service, $relativePath, 'get');
     }
 
     /**
@@ -141,6 +80,168 @@ class HorizonApiProxyService
         $path = (string) config('horizonhub.horizon_paths.pending_jobs');
 
         return $this->private__call($service, "$path?".\http_build_query($this->private__buildJobListQuery($query)), 'get');
+    }
+
+    /**
+     * Get high-level dashboard statistics (including jobs per minute and recent jobs)
+     * from the Horizon HTTP API for a service.
+     *
+     * This proxies the Horizon `/stats` endpoint and returns its decoded payload.
+     *
+     * @param  Service  $service  The service.
+     * @return array{success: bool, message?: string, status?: int, data?: array}
+     */
+    public function getStats(Service $service): array
+    {
+        $relativePath = (string) config('horizonhub.horizon_paths.ping');
+
+        return $this->private__call($service, $relativePath, 'get');
+    }
+
+    /**
+     * Get the queue workload from the Horizon HTTP API for a service.
+     *
+     * @param  Service  $service  The service.
+     * @return array{success: bool, message?: string, status?: int, data?: array}
+     */
+    public function getWorkload(Service $service): array
+    {
+        $relativePath = (string) config('horizonhub.horizon_paths.workload');
+
+        $result = $this->private__call($service, $relativePath, 'get');
+        if (! ($result['success'] ?? false) && \in_array($result['status'] ?? 0, [401, 403], true)) {
+            $result = $this->private__call($service, $relativePath, 'get', true);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Test connectivity with the Horizon HTTP API for a service.
+     *
+     * @param  Service  $service  The service.
+     * @return array{success: bool, message?: string, status?: int}
+     */
+    public function ping(Service $service): array
+    {
+        $relativePath = (string) config('horizonhub.horizon_paths.ping');
+
+        return $this->private__call($service, $relativePath, 'get');
+    }
+
+    /**
+     * Retry a job through the Horizon HTTP API.
+     *
+     * @param  Service  $service  The service.
+     * @param  string  $jobUuid  The job UUID.
+     * @return array{success: bool, message?: string, status?: int}
+     */
+    public function retryJob(Service $service, string $jobUuid): array
+    {
+        $relativePath = \str_replace('{id}', $jobUuid, (string) config('horizonhub.horizon_paths.retry'));
+
+        return $this->private__call($service, $relativePath, 'post', true);
+    }
+
+    /**
+     * Bootstrap a Horizon dashboard session and CSRF token.
+     *
+     * This simulates a browser visiting the Horizon dashboard to obtain
+     * a session and CSRF token that can be used to call Horizon's API
+     * endpoints protected by CSRF.
+     *
+     * @param  Service  $service  The service.
+     * @return array{csrf_token: string, cookies: CookieJar}|null
+     */
+    private function private__bootstrapDashboardSession(Service $service): ?array
+    {
+        $serviceBase = $service->getBaseUrl();
+        if ($serviceBase === '') {
+            Log::warning('Horizon Hub: failed to build Horizon dashboard URL', [
+                'service_id' => $service->id ?? null,
+                'error' => 'missing base_url',
+            ]);
+
+            return null;
+        }
+
+        $dashboardUrl = "$serviceBase/".\ltrim((string) config('horizonhub.horizon_paths.dashboard'), '/');
+
+        $cookieJar = new CookieJar;
+
+        try {
+            $response = $this->private__newHorizonPendingRequest()
+                ->withOptions(['cookies' => $cookieJar])
+                ->get($dashboardUrl);
+        } catch (\Throwable $e) {
+            Log::warning('Horizon Hub: failed to bootstrap Horizon dashboard session', [
+                'service_id' => $service->id ?? null,
+                'url' => $dashboardUrl,
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+
+        if (! $response->ok()) {
+            Log::warning('Horizon Hub: unexpected status when bootstrapping Horizon dashboard session', [
+                'service_id' => $service->id ?? null,
+                'url' => $dashboardUrl,
+                'status' => $response->status(),
+            ]);
+
+            return null;
+        }
+
+        $html = $response->body();
+        $matches = [];
+
+        if (! \preg_match('/<meta\s+name=["\']csrf-token["\']\s+content=["\']([^"\']+)["\']/', $html, $matches)) {
+            Log::warning('Horizon Hub: unable to extract CSRF token from Horizon dashboard', [
+                'service_id' => $service->id ?? null,
+                'url' => $dashboardUrl,
+            ]);
+
+            return null;
+        }
+
+        $csrfToken = (string) ($matches[1] ?? '');
+        if ($csrfToken === '') {
+            Log::warning('Horizon Hub: empty CSRF token extracted from Horizon dashboard', [
+                'service_id' => $service->id ?? null,
+                'url' => $dashboardUrl,
+            ]);
+
+            return null;
+        }
+
+        return [
+            'csrf_token' => $csrfToken,
+            'cookies' => $cookieJar,
+        ];
+    }
+
+    /**
+     * Build an error message from a response.
+     *
+     * @param  Response  $response  The response.
+     */
+    private function private__buildErrorMessageFromResponse(Response $response): string
+    {
+        $rawBody = $response->body();
+        $decoded = \json_decode($rawBody, true);
+
+        if (\is_array($decoded) && isset($decoded['message']) && (string) $decoded['message'] !== '') {
+            return (string) $decoded['message'];
+        }
+
+        $trimmedBody = \trim((string) $rawBody);
+        $isHtml = $trimmedBody !== \strip_tags($trimmedBody);
+        if (! $isHtml && $trimmedBody !== '') {
+            return \mb_substr($trimmedBody, 0, 200);
+        }
+
+        return "Horizon API returned an HTTP error ({$response->status()}).";
     }
 
     /**
@@ -238,84 +339,6 @@ class HorizonApiProxyService
     }
 
     /**
-     * Bootstrap a Horizon dashboard session and CSRF token.
-     *
-     * This simulates a browser visiting the Horizon dashboard to obtain
-     * a session and CSRF token that can be used to call Horizon's API
-     * endpoints protected by CSRF.
-     *
-     * @param  Service  $service  The service.
-     * @return array{csrf_token: string, cookies: CookieJar}|null
-     */
-    private function private__bootstrapDashboardSession(Service $service): ?array
-    {
-        $serviceBase = $service->getBaseUrl();
-        if ($serviceBase === '') {
-            Log::warning('Horizon Hub: failed to build Horizon dashboard URL', [
-                'service_id' => $service->id ?? null,
-                'error' => 'missing base_url',
-            ]);
-
-            return null;
-        }
-
-        $dashboardUrl = "$serviceBase/".\ltrim((string) config('horizonhub.horizon_paths.dashboard'), '/');
-
-        $cookieJar = new CookieJar;
-
-        try {
-            $response = $this->private__newHorizonPendingRequest()
-                ->withOptions(['cookies' => $cookieJar])
-                ->get($dashboardUrl);
-        } catch (\Throwable $e) {
-            Log::warning('Horizon Hub: failed to bootstrap Horizon dashboard session', [
-                'service_id' => $service->id ?? null,
-                'url' => $dashboardUrl,
-                'error' => $e->getMessage(),
-            ]);
-
-            return null;
-        }
-
-        if (! $response->ok()) {
-            Log::warning('Horizon Hub: unexpected status when bootstrapping Horizon dashboard session', [
-                'service_id' => $service->id ?? null,
-                'url' => $dashboardUrl,
-                'status' => $response->status(),
-            ]);
-
-            return null;
-        }
-
-        $html = $response->body();
-        $matches = [];
-
-        if (! \preg_match('/<meta\s+name=["\']csrf-token["\']\s+content=["\']([^"\']+)["\']/', $html, $matches)) {
-            Log::warning('Horizon Hub: unable to extract CSRF token from Horizon dashboard', [
-                'service_id' => $service->id ?? null,
-                'url' => $dashboardUrl,
-            ]);
-
-            return null;
-        }
-
-        $csrfToken = (string) ($matches[1] ?? '');
-        if ($csrfToken === '') {
-            Log::warning('Horizon Hub: empty CSRF token extracted from Horizon dashboard', [
-                'service_id' => $service->id ?? null,
-                'url' => $dashboardUrl,
-            ]);
-
-            return null;
-        }
-
-        return [
-            'csrf_token' => $csrfToken,
-            'cookies' => $cookieJar,
-        ];
-    }
-
-    /**
      * Build an HTTP client for Horizon calls with unified timeout and optional GET retries.
      *
      * @param  string  $httpMethod  The HTTP method.
@@ -403,28 +426,5 @@ class HorizonApiProxyService
             'message' => $message,
             'status' => $response->status(),
         ];
-    }
-
-    /**
-     * Build an error message from a response.
-     *
-     * @param  Response  $response  The response.
-     */
-    private function private__buildErrorMessageFromResponse(Response $response): string
-    {
-        $rawBody = $response->body();
-        $decoded = \json_decode($rawBody, true);
-
-        if (\is_array($decoded) && isset($decoded['message']) && (string) $decoded['message'] !== '') {
-            return (string) $decoded['message'];
-        }
-
-        $trimmedBody = \trim((string) $rawBody);
-        $isHtml = $trimmedBody !== \strip_tags($trimmedBody);
-        if (! $isHtml && $trimmedBody !== '') {
-            return \mb_substr($trimmedBody, 0, 200);
-        }
-
-        return "Horizon API returned an HTTP error ({$response->status()}).";
     }
 }

--- a/app/Services/Horizon/HorizonJobListService.php
+++ b/app/Services/Horizon/HorizonJobListService.php
@@ -28,40 +28,6 @@ class HorizonJobListService
     }
 
     /**
-     * Build paginators for processing, processed, and failed job lists (aggregated across services).
-     *
-     * @param  Collection<int, Service>  $services
-     * @param  string  $search  The search.
-     * @param  int  $pageProcessing  The page processing.
-     * @param  int  $pageProcessed  The page processed.
-     * @param  int  $pageFailed  The page failed.
-     * @param  int  $perPage  The per page.
-     * @param  string  $path  The path.
-     * @param  array<string, mixed>  $query  The query.
-     * @return array{processing: LengthAwarePaginator, processed: LengthAwarePaginator, failed: LengthAwarePaginator}
-     */
-    public function buildAggregatedStatusPaginators(
-        Collection $services,
-        string $search,
-        int $pageProcessing,
-        int $pageProcessed,
-        int $pageFailed,
-        int $perPage,
-        string $path,
-        array $query,
-    ): array {
-        $jobsProcessing = $this->private__collectAndSortJobsForServices($services, 'processing', $search);
-        $jobsProcessed = $this->private__collectAndSortJobsForServices($services, 'processed', $search);
-        $jobsFailed = $this->private__collectAndSortJobsForServices($services, 'failed', $search);
-
-        return [
-            'processing' => $this->private__makePaginator($jobsProcessing, $perPage, $pageProcessing, $path, $query, 'page_processing'),
-            'processed' => $this->private__makePaginator($jobsProcessed, $perPage, $pageProcessed, $path, $query, 'page_processed'),
-            'failed' => $this->private__makePaginator($jobsFailed, $perPage, $pageFailed, $path, $query, 'page_failed'),
-        ];
-    }
-
-    /**
      * Aggregated jobs index paginators from the current request query.
      *
      * @param  Request  $request  The request.
@@ -113,6 +79,79 @@ class HorizonJobListService
     }
 
     /**
+     * Build paginators for processing, processed, and failed job lists (aggregated across services).
+     *
+     * @param  Collection<int, Service>  $services
+     * @param  string  $search  The search.
+     * @param  int  $pageProcessing  The page processing.
+     * @param  int  $pageProcessed  The page processed.
+     * @param  int  $pageFailed  The page failed.
+     * @param  int  $perPage  The per page.
+     * @param  string  $path  The path.
+     * @param  array<string, mixed>  $query  The query.
+     * @return array{processing: LengthAwarePaginator, processed: LengthAwarePaginator, failed: LengthAwarePaginator}
+     */
+    public function buildAggregatedStatusPaginators(
+        Collection $services,
+        string $search,
+        int $pageProcessing,
+        int $pageProcessed,
+        int $pageFailed,
+        int $perPage,
+        string $path,
+        array $query,
+    ): array {
+        $jobsProcessing = $this->private__collectAndSortJobsForServices($services, 'processing', $search);
+        $jobsProcessed = $this->private__collectAndSortJobsForServices($services, 'processed', $search);
+        $jobsFailed = $this->private__collectAndSortJobsForServices($services, 'failed', $search);
+
+        return [
+            'processing' => $this->private__makePaginator($jobsProcessing, $perPage, $pageProcessing, $path, $query, 'page_processing'),
+            'processed' => $this->private__makePaginator($jobsProcessed, $perPage, $pageProcessed, $path, $query, 'page_processed'),
+            'failed' => $this->private__makePaginator($jobsFailed, $perPage, $pageFailed, $path, $query, 'page_failed'),
+        ];
+    }
+
+    /**
+     * Fetch failed jobs from one or more services, apply filters, sort, and slice for HTTP pagination.
+     *
+     * @param  Collection<int, Service>  $services
+     * @param  string  $search  The search.
+     * @param  mixed  $dateFrom  The date from.
+     * @param  mixed  $dateTo  The date to.
+     * @param  int  $page  The page.
+     * @param  int  $perPage  The per page.
+     * @return array{rows: list<array<string, mixed>>, total: int, last_page: int}
+     */
+    public function buildFailedJobsRetryModalPage(
+        Collection $services,
+        string $search,
+        mixed $dateFrom,
+        mixed $dateTo,
+        int $page,
+        int $perPage,
+    ): array {
+        $rows = $this->private__buildRetryModalFailedRows($services, $search, $dateFrom, $dateTo);
+
+        $total = \count($rows);
+        $lastPage = $perPage > 0 ? (int) \max(1, (int) \ceil($total / $perPage)) : 1;
+        $offset = ($page - 1) * $perPage;
+        $pageRows = $perPage > 0 ? \array_slice($rows, $offset, $perPage) : $rows;
+
+        $data = [];
+        foreach ($pageRows as $row) {
+            unset($row['failed_at']);
+            $data[] = $row;
+        }
+
+        return [
+            'rows' => $data,
+            'total' => $total,
+            'last_page' => $lastPage,
+        ];
+    }
+
+    /**
      * Build paginators for a single service dashboard (same three sections).
      *
      * @param  Service  $service  The service.
@@ -146,6 +185,22 @@ class HorizonJobListService
             'processed' => $this->private__makePaginator($jobsProcessed, $perPage, $pageProcessed, $path, $query, 'page_processed'),
             'failed' => $this->private__makePaginator($jobsFailed, $perPage, $pageFailed, $path, $query, 'page_failed'),
         ];
+    }
+
+    /**
+     * Get the API fetcher for a given status.
+     *
+     * @param  Service  $service  The service.
+     * @param  string  $status  The status.
+     * @return callable(array<string, mixed>): array{success: bool, data?: array<string, mixed>}
+     */
+    private function private__apiFetcherForStatus(Service $service, string $status): callable
+    {
+        return match ($status) {
+            'processing' => fn (array $query): array => $this->horizonApi->getPendingJobs($service, $query),
+            'processed' => fn (array $query): array => $this->horizonApi->getCompletedJobs($service, $query),
+            'failed' => fn (array $query): array => $this->horizonApi->getFailedJobs($service, $query),
+        };
     }
 
     /**
@@ -249,45 +304,6 @@ class HorizonJobListService
     }
 
     /**
-     * Fetch failed jobs from one or more services, apply filters, sort, and slice for HTTP pagination.
-     *
-     * @param  Collection<int, Service>  $services
-     * @param  string  $search  The search.
-     * @param  mixed  $dateFrom  The date from.
-     * @param  mixed  $dateTo  The date to.
-     * @param  int  $page  The page.
-     * @param  int  $perPage  The per page.
-     * @return array{rows: list<array<string, mixed>>, total: int, last_page: int}
-     */
-    public function buildFailedJobsRetryModalPage(
-        Collection $services,
-        string $search,
-        mixed $dateFrom,
-        mixed $dateTo,
-        int $page,
-        int $perPage,
-    ): array {
-        $rows = $this->private__buildRetryModalFailedRows($services, $search, $dateFrom, $dateTo);
-
-        $total = \count($rows);
-        $lastPage = $perPage > 0 ? (int) \max(1, (int) \ceil($total / $perPage)) : 1;
-        $offset = ($page - 1) * $perPage;
-        $pageRows = $perPage > 0 ? \array_slice($rows, $offset, $perPage) : $rows;
-
-        $data = [];
-        foreach ($pageRows as $row) {
-            unset($row['failed_at']);
-            $data[] = $row;
-        }
-
-        return [
-            'rows' => $data,
-            'total' => $total,
-            'last_page' => $lastPage,
-        ];
-    }
-
-    /**
      * Collect and sort jobs for one or more services.
      *
      * @param  Collection<int, Service>  $services  The services.
@@ -365,35 +381,52 @@ class HorizonJobListService
     }
 
     /**
-     * Get the API fetcher for a given status.
+     * Make a paginator for a given collection of items.
      *
-     * @param  Service  $service  The service.
-     * @param  string  $status  The status.
-     * @return callable(array<string, mixed>): array{success: bool, data?: array<string, mixed>}
+     * @param  Collection<int, object>  $items  The items.
+     * @param  int  $perPage  The per page.
+     * @param  int  $page  The page.
+     * @param  string  $path  The path.
+     * @param  array<string, mixed>  $query  The query.
+     * @param  string  $pageName  The page name.
      */
-    private function private__apiFetcherForStatus(Service $service, string $status): callable
-    {
-        return match ($status) {
-            'processing' => fn (array $query): array => $this->horizonApi->getPendingJobs($service, $query),
-            'processed' => fn (array $query): array => $this->horizonApi->getCompletedJobs($service, $query),
-            'failed' => fn (array $query): array => $this->horizonApi->getFailedJobs($service, $query),
-        };
-    }
+    private function private__makePaginator(
+        Collection $items,
+        int $perPage,
+        int $page,
+        string $path,
+        array $query,
+        string $pageName,
+    ): LengthAwarePaginator {
+        $page = \max(1, $page);
+        $total = $items->count();
 
-    /**
-     * Get the next starting at value for the next batch.
-     *
-     * @param  int  $startingAt  The starting at.
-     * @param  list<mixed>  $batch  The batch.
-     */
-    private function private__nextStartingAt(int $startingAt, array $batch): int
-    {
-        $last = $batch[\array_key_last($batch)];
-        if (\is_array($last) && isset($last['index'])) {
-            return (int) $last['index'];
+        if ($perPage <= 0) {
+            $paginator = new LengthAwarePaginator(
+                $items,
+                $total,
+                \max(1, $total > 0 ? $total : 1),
+                1,
+                ['path' => $path, 'query' => $query]
+            );
+            $paginator->setPageName($pageName);
+
+            return $paginator;
         }
 
-        return \max(0, $startingAt + 1) + \count($batch) - 1;
+        $offset = ($page - 1) * $perPage;
+        $slice = $items->slice($offset, $perPage)->values();
+
+        $paginator = new LengthAwarePaginator(
+            $slice,
+            $total,
+            $perPage,
+            $page,
+            ['path' => $path, 'query' => $query]
+        );
+        $paginator->setPageName($pageName);
+
+        return $paginator;
     }
 
     /**
@@ -478,6 +511,22 @@ class HorizonJobListService
     }
 
     /**
+     * Get the next starting at value for the next batch.
+     *
+     * @param  int  $startingAt  The starting at.
+     * @param  list<mixed>  $batch  The batch.
+     */
+    private function private__nextStartingAt(int $startingAt, array $batch): int
+    {
+        $last = $batch[\array_key_last($batch)];
+        if (\is_array($last) && isset($last['index'])) {
+            return (int) $last['index'];
+        }
+
+        return \max(0, $startingAt + 1) + \count($batch) - 1;
+    }
+
+    /**
      * Sort job rows by time for a given status.
      *
      * @param  Collection<int, object>  $rows
@@ -523,54 +572,5 @@ class HorizonJobListService
         }
 
         return 0.0;
-    }
-
-    /**
-     * Make a paginator for a given collection of items.
-     *
-     * @param  Collection<int, object>  $items  The items.
-     * @param  int  $perPage  The per page.
-     * @param  int  $page  The page.
-     * @param  string  $path  The path.
-     * @param  array<string, mixed>  $query  The query.
-     * @param  string  $pageName  The page name.
-     */
-    private function private__makePaginator(
-        Collection $items,
-        int $perPage,
-        int $page,
-        string $path,
-        array $query,
-        string $pageName,
-    ): LengthAwarePaginator {
-        $page = \max(1, $page);
-        $total = $items->count();
-
-        if ($perPage <= 0) {
-            $paginator = new LengthAwarePaginator(
-                $items,
-                $total,
-                \max(1, $total > 0 ? $total : 1),
-                1,
-                ['path' => $path, 'query' => $query]
-            );
-            $paginator->setPageName($pageName);
-
-            return $paginator;
-        }
-
-        $offset = ($page - 1) * $perPage;
-        $slice = $items->slice($offset, $perPage)->values();
-
-        $paginator = new LengthAwarePaginator(
-            $slice,
-            $total,
-            $perPage,
-            $page,
-            ['path' => $path, 'query' => $query]
-        );
-        $paginator->setPageName($pageName);
-
-        return $paginator;
     }
 }

--- a/app/Services/Horizon/HorizonMetricsService.php
+++ b/app/Services/Horizon/HorizonMetricsService.php
@@ -22,24 +22,19 @@ class HorizonMetricsService
     private const TOP_N_QUEUES = 12;
 
     /**
-     * The jobs throughput metrics calculator.
-     */
-    private JobsThroughputMetricsCalculator $jobsThroughputMetrics;
-
-    /**
-     * The workload metrics calculator.
-     */
-    private WorkloadMetricsCalculator $workloadMetrics;
-
-    /**
      * The failure metrics calculator.
      */
     private FailureMetricsCalculator $failureMetrics;
 
     /**
-     * The runtime metrics calculator.
+     * The jobs throughput metrics calculator.
      */
-    private RuntimeMetricsCalculator $runtimeMetrics;
+    private JobsThroughputMetricsCalculator $jobsThroughputMetrics;
+
+    /**
+     * The jobs volume (last 24h) calculator.
+     */
+    private JobsVolumeLast24hCalculator $jobsVolumeLast24h;
 
     /**
      * The queue failure counters calculator.
@@ -47,9 +42,14 @@ class HorizonMetricsService
     private QueueFailureCountersCalculator $queueFailureCounters;
 
     /**
-     * The jobs volume (last 24h) calculator.
+     * The runtime metrics calculator.
      */
-    private JobsVolumeLast24hCalculator $jobsVolumeLast24h;
+    private RuntimeMetricsCalculator $runtimeMetrics;
+
+    /**
+     * The workload metrics calculator.
+     */
+    private WorkloadMetricsCalculator $workloadMetrics;
 
     /**
      * Construct the Horizon metrics service.
@@ -62,95 +62,6 @@ class HorizonMetricsService
         $this->runtimeMetrics = new RuntimeMetricsCalculator($horizonApi);
         $this->queueFailureCounters = new QueueFailureCountersCalculator($horizonApi);
         $this->jobsVolumeLast24h = new JobsVolumeLast24hCalculator($horizonApi);
-    }
-
-    /**
-     * Get the number of jobs processed in the past minute.
-     */
-    public function getJobsPastMinute(?Service $service = null): int
-    {
-        return $this->jobsThroughputMetrics->getJobsPastMinute($service);
-    }
-
-    /**
-     * Get the number of jobs processed in the past hour.
-     */
-    public function getJobsPastHour(?Service $service = null): int
-    {
-        return $this->jobsThroughputMetrics->getJobsPastHour($service);
-    }
-
-    /**
-     * Get the number of jobs failed in the past seven days.
-     */
-    public function getFailedPastSevenDays(?Service $service = null): int
-    {
-        return $this->jobsThroughputMetrics->getFailedPastSevenDays($service);
-    }
-
-    /**
-     * Aggregate throughput counters for no filter (all services) or a subset by id.
-     *
-     * @param  list<int>  $serviceIds
-     * @return array{jobsPastMinute: int, jobsPastHour: int, failedPastSevenDays: int}
-     */
-    public function getThroughputTotalsForServiceIds(array $serviceIds): array
-    {
-        if ($serviceIds === []) {
-            return [
-                'jobsPastMinute' => $this->getJobsPastMinute(null),
-                'jobsPastHour' => $this->getJobsPastHour(null),
-                'failedPastSevenDays' => $this->getFailedPastSevenDays(null),
-            ];
-        }
-
-        $minute = 0;
-        $hour = 0;
-        $failed = 0;
-
-        $services = Service::query()->whereIn('id', $serviceIds)->orderBy('name')->get();
-        /** @var Service $service */
-        foreach ($services as $service) {
-            $minute += $this->getJobsPastMinute($service);
-            $hour += $this->getJobsPastHour($service);
-            $failed += $this->getFailedPastSevenDays($service);
-        }
-
-        return [
-            'jobsPastMinute' => $minute,
-            'jobsPastHour' => $hour,
-            'failedPastSevenDays' => $failed,
-        ];
-    }
-
-    /**
-     * Get the workload for a single service.
-     *
-     * @return array<int, array{queue: string, jobs: int, processes: int|null, wait: float|null}>
-     */
-    public function getWorkloadForService(Service $service): array
-    {
-        return $this->workloadMetrics->getWorkloadForService($service);
-    }
-
-    /**
-     * Get the supervisors data for a single service.
-     *
-     * @return array<int, array{name: string, status: string, processes: int, last_heartbeat: string, options: array<string, mixed>}>
-     */
-    public function getSupervisorsData(array $serviceScope = []): array
-    {
-        return $this->workloadMetrics->getSupervisorsData($serviceScope);
-    }
-
-    /**
-     * Get the workload data for a single service.
-     *
-     * @return array<int, array{service_id: int, service: string, queue: string, jobs: int, processes: int|null, wait: float|null}>
-     */
-    public function getWorkloadData(array $serviceScope = []): array
-    {
-        return $this->workloadMetrics->getWorkloadData($serviceScope);
     }
 
     /**
@@ -200,6 +111,14 @@ class HorizonMetricsService
     }
 
     /**
+     * Get the number of jobs failed in the past seven days.
+     */
+    public function getFailedPastSevenDays(?Service $service = null): int
+    {
+        return $this->jobsThroughputMetrics->getFailedPastSevenDays($service);
+    }
+
+    /**
      * Get the failure rate from 00:00 of the previous day until now.
      *
      * @return array{rate: float, processed: int, failed: int}
@@ -220,16 +139,6 @@ class HorizonMetricsService
     }
 
     /**
-     * Get hourly completed and failed job counts over the rolling last 24 hours.
-     *
-     * @return array{xAxis: list<string>, completed: list<int>, failed: list<int>}
-     */
-    public function getJobsVolumeLast24h(array $serviceScope = []): array
-    {
-        return $this->jobsVolumeLast24h->getJobsVolumeLast24h($serviceScope);
-    }
-
-    /**
      * Get per-job runtimes over the rolling last 24 hours (completed and failed).
      *
      * @return array{points: list<array{endAtMs: int, seconds: float, name: string, service: string, status: string}>}
@@ -237,6 +146,42 @@ class HorizonMetricsService
     public function getJobRuntimesLast24h(array $serviceScope = []): array
     {
         return $this->runtimeMetrics->getJobRuntimesLast24h($serviceScope);
+    }
+
+    /**
+     * Get the number of jobs processed in the past hour.
+     */
+    public function getJobsPastHour(?Service $service = null): int
+    {
+        return $this->jobsThroughputMetrics->getJobsPastHour($service);
+    }
+
+    /**
+     * Get the number of jobs processed in the past hour by service.
+     *
+     * @return array<int, array{service_id: int, service: string, jobs: int}>
+     */
+    public function getJobsPastHourByService(): array
+    {
+        return $this->jobsThroughputMetrics->getJobsPastHourByService();
+    }
+
+    /**
+     * Get the number of jobs processed in the past minute.
+     */
+    public function getJobsPastMinute(?Service $service = null): int
+    {
+        return $this->jobsThroughputMetrics->getJobsPastMinute($service);
+    }
+
+    /**
+     * Get hourly completed and failed job counts over the rolling last 24 hours.
+     *
+     * @return array{xAxis: list<string>, completed: list<int>, failed: list<int>}
+     */
+    public function getJobsVolumeLast24h(array $serviceScope = []): array
+    {
+        return $this->jobsVolumeLast24h->getJobsVolumeLast24h($serviceScope);
     }
 
     /**
@@ -250,13 +195,48 @@ class HorizonMetricsService
     }
 
     /**
-     * Get the number of jobs processed in the past hour by service.
+     * Get the supervisors data for a single service.
      *
-     * @return array<int, array{service_id: int, service: string, jobs: int}>
+     * @return array<int, array{name: string, status: string, processes: int, last_heartbeat: string, options: array<string, mixed>}>
      */
-    public function getJobsPastHourByService(): array
+    public function getSupervisorsData(array $serviceScope = []): array
     {
-        return $this->jobsThroughputMetrics->getJobsPastHourByService();
+        return $this->workloadMetrics->getSupervisorsData($serviceScope);
+    }
+
+    /**
+     * Aggregate throughput counters for no filter (all services) or a subset by id.
+     *
+     * @param  list<int>  $serviceIds
+     * @return array{jobsPastMinute: int, jobsPastHour: int, failedPastSevenDays: int}
+     */
+    public function getThroughputTotalsForServiceIds(array $serviceIds): array
+    {
+        if ($serviceIds === []) {
+            return [
+                'jobsPastMinute' => $this->getJobsPastMinute(null),
+                'jobsPastHour' => $this->getJobsPastHour(null),
+                'failedPastSevenDays' => $this->getFailedPastSevenDays(null),
+            ];
+        }
+
+        $minute = 0;
+        $hour = 0;
+        $failed = 0;
+
+        $services = Service::query()->whereIn('id', $serviceIds)->orderBy('name')->get();
+        /** @var Service $service */
+        foreach ($services as $service) {
+            $minute += $this->getJobsPastMinute($service);
+            $hour += $this->getJobsPastHour($service);
+            $failed += $this->getFailedPastSevenDays($service);
+        }
+
+        return [
+            'jobsPastMinute' => $minute,
+            'jobsPastHour' => $hour,
+            'failedPastSevenDays' => $failed,
+        ];
     }
 
     /**
@@ -296,5 +276,25 @@ class HorizonMetricsService
         $wait = \array_values($top);
 
         return ['queues' => $queues, 'wait' => $wait];
+    }
+
+    /**
+     * Get the workload data for a single service.
+     *
+     * @return array<int, array{service_id: int, service: string, queue: string, jobs: int, processes: int|null, wait: float|null}>
+     */
+    public function getWorkloadData(array $serviceScope = []): array
+    {
+        return $this->workloadMetrics->getWorkloadData($serviceScope);
+    }
+
+    /**
+     * Get the workload for a single service.
+     *
+     * @return array<int, array{queue: string, jobs: int, processes: int|null, wait: float|null}>
+     */
+    public function getWorkloadForService(Service $service): array
+    {
+        return $this->workloadMetrics->getWorkloadForService($service);
     }
 }

--- a/app/Services/Horizon/ServiceShowPageDataService.php
+++ b/app/Services/Horizon/ServiceShowPageDataService.php
@@ -10,14 +10,14 @@ use Illuminate\Support\Collection;
 class ServiceShowPageDataService
 {
     /**
-     * The Horizon metrics service.
-     */
-    private HorizonMetricsService $metrics;
-
-    /**
      * The Horizon job list service.
      */
     private HorizonJobListService $jobList;
+
+    /**
+     * The Horizon metrics service.
+     */
+    private HorizonMetricsService $metrics;
 
     /**
      * The constructor.

--- a/app/Services/Metrics/HorizonMetricsComputation.php
+++ b/app/Services/Metrics/HorizonMetricsComputation.php
@@ -38,6 +38,72 @@ abstract class HorizonMetricsComputation
     }
 
     /**
+     * Aggregate queue counters from Horizon jobs payload.
+     *
+     * @param  mixed  $jobsPayload  The jobs payload.
+     * @param  int  $sinceTimestamp  The since timestamp.
+     * @param  string  $timestampField  The timestamp field.
+     * @param  array<string, int>  $queueCounts  The queue counts.
+     */
+    protected function private__aggregateQueueCountsFromJobsPayload(mixed $jobsPayload, int $sinceTimestamp, string $timestampField, array &$queueCounts): void
+    {
+        foreach ($jobsPayload as $job) {
+            if (! \is_array($job)) {
+                continue;
+            }
+
+            $tsRaw = $job[$timestampField] ?? null;
+            if (! \is_numeric($tsRaw) || (int) $tsRaw < $sinceTimestamp) {
+                continue;
+            }
+
+            $queueRaw = isset($job['queue']) ? (string) $job['queue'] : '';
+            $queue = QueueNameNormalizer::normalize($queueRaw);
+            if ($queue === null) {
+                $queue = $queueRaw;
+            }
+
+            if (! isset($queueCounts[$queue])) {
+                $queueCounts[$queue] = 0;
+            }
+
+            $queueCounts[$queue]++;
+        }
+    }
+
+    /**
+     * Extract a normalized queue list from supervisor options.
+     *
+     * @param  array<string, mixed>  $options
+     * @return array<int, string>
+     */
+    protected function private__extractQueuesFromSupervisorOptions(array $options): array
+    {
+        $queues = $options['queue'] ?? null;
+        if (! \is_array($queues)) {
+            if (empty($queues)) {
+                return [];
+            }
+
+            $queue = QueueNameNormalizer::normalize((string) $queues);
+
+            return $queue !== null && $queue !== '' ? [$queue] : [];
+        }
+
+        $normalizedQueues = [];
+        foreach ($queues as $queue) {
+            $normalizedQueue = QueueNameNormalizer::normalize((string) $queue);
+            if (empty($normalizedQueue)) {
+                continue;
+            }
+
+            $normalizedQueues[$normalizedQueue] = true;
+        }
+
+        return \array_keys($normalizedQueues);
+    }
+
+    /**
      * Fetch completed jobs with completed_at >= $sinceTimestamp by paginating the Horizon API.
      *
      * Each request uses Horizon query `limit` = horizonhub.horizon_api_job_list_page_size.
@@ -152,22 +218,6 @@ abstract class HorizonMetricsComputation
     }
 
     /**
-     * Next Horizon jobs list cursor: starting_at is a zero-based index into the Redis-backed list, not a unix timestamp.
-     *
-     * @param  int  $startingAt  The starting at.
-     * @param  array<int, mixed>  $batch  The batch.
-     */
-    protected function private__nextMetricsJobsStartingAt(int $startingAt, array $batch): int
-    {
-        $last = $batch[\array_key_last($batch)];
-        if (\is_array($last) && isset($last['index'])) {
-            return (int) $last['index'];
-        }
-
-        return \max(0, $startingAt + 1) + \count($batch) - 1;
-    }
-
-    /**
      * Get services that can provide Horizon metrics.
      *
      * @param  list<int>|null  $serviceScope  The service scope. Empty = all services with base_url; non-empty = restrict by id.
@@ -199,113 +249,6 @@ abstract class HorizonMetricsComputation
         }
 
         return $servicesQuery->get();
-    }
-
-    /**
-     * Initialize hourly buckets between $since and $endHour (inclusive).
-     *
-     * @param  Carbon  $since  The since.
-     * @param  Carbon  $endHour  The end hour.
-     * @param  string  $bucketFormat  The bucket format.
-     * @param  int  $maxBuckets  The max buckets.
-     * @param  callable(): array  $bucketInitializer  The bucket initializer.
-     * @return array<string, array<string, mixed>>
-     */
-    protected function private__initHourlyBuckets(Carbon $since, Carbon $endHour, string $bucketFormat, int $maxBuckets, callable $bucketInitializer): array
-    {
-        $buckets = [];
-        $bucketStart = $since->copy();
-
-        while ($bucketStart <= $endHour && \count($buckets) < $maxBuckets) {
-            $key = $bucketStart->format($bucketFormat);
-            $buckets[$key] = $bucketInitializer();
-            $bucketStart->addHour();
-        }
-
-        return $buckets;
-    }
-
-    /**
-     * Extract a normalized queue list from supervisor options.
-     *
-     * @param  array<string, mixed>  $options
-     * @return array<int, string>
-     */
-    protected function private__extractQueuesFromSupervisorOptions(array $options): array
-    {
-        $queues = $options['queue'] ?? null;
-        if (! \is_array($queues)) {
-            if (empty($queues)) {
-                return [];
-            }
-
-            $queue = QueueNameNormalizer::normalize((string) $queues);
-
-            return $queue !== null && $queue !== '' ? [$queue] : [];
-        }
-
-        $normalizedQueues = [];
-        foreach ($queues as $queue) {
-            $normalizedQueue = QueueNameNormalizer::normalize((string) $queue);
-            if (empty($normalizedQueue)) {
-                continue;
-            }
-
-            $normalizedQueues[$normalizedQueue] = true;
-        }
-
-        return \array_keys($normalizedQueues);
-    }
-
-    /**
-     * Sum jobs by queue names using a precomputed lookup table.
-     *
-     * @param  array<int, string>  $queueNames
-     * @param  array<string, int>  $jobsByQueue
-     */
-    protected function private__sumJobsByQueueNames(array $queueNames, array $jobsByQueue): int
-    {
-        $jobs = 0;
-
-        foreach ($queueNames as $q) {
-            $jobs += $jobsByQueue[$q] ?? 0;
-        }
-
-        return $jobs;
-    }
-
-    /**
-     * Aggregate queue counters from Horizon jobs payload.
-     *
-     * @param  mixed  $jobsPayload  The jobs payload.
-     * @param  int  $sinceTimestamp  The since timestamp.
-     * @param  string  $timestampField  The timestamp field.
-     * @param  array<string, int>  $queueCounts  The queue counts.
-     */
-    protected function private__aggregateQueueCountsFromJobsPayload(mixed $jobsPayload, int $sinceTimestamp, string $timestampField, array &$queueCounts): void
-    {
-        foreach ($jobsPayload as $job) {
-            if (! \is_array($job)) {
-                continue;
-            }
-
-            $tsRaw = $job[$timestampField] ?? null;
-            if (! \is_numeric($tsRaw) || (int) $tsRaw < $sinceTimestamp) {
-                continue;
-            }
-
-            $queueRaw = isset($job['queue']) ? (string) $job['queue'] : '';
-            $queue = QueueNameNormalizer::normalize($queueRaw);
-            if ($queue === null) {
-                $queue = $queueRaw;
-            }
-
-            if (! isset($queueCounts[$queue])) {
-                $queueCounts[$queue] = 0;
-            }
-
-            $queueCounts[$queue]++;
-        }
     }
 
     /**
@@ -375,5 +318,62 @@ abstract class HorizonMetricsComputation
         }
 
         return $rows;
+    }
+
+    /**
+     * Initialize hourly buckets between $since and $endHour (inclusive).
+     *
+     * @param  Carbon  $since  The since.
+     * @param  Carbon  $endHour  The end hour.
+     * @param  string  $bucketFormat  The bucket format.
+     * @param  int  $maxBuckets  The max buckets.
+     * @param  callable(): array  $bucketInitializer  The bucket initializer.
+     * @return array<string, array<string, mixed>>
+     */
+    protected function private__initHourlyBuckets(Carbon $since, Carbon $endHour, string $bucketFormat, int $maxBuckets, callable $bucketInitializer): array
+    {
+        $buckets = [];
+        $bucketStart = $since->copy();
+
+        while ($bucketStart <= $endHour && \count($buckets) < $maxBuckets) {
+            $key = $bucketStart->format($bucketFormat);
+            $buckets[$key] = $bucketInitializer();
+            $bucketStart->addHour();
+        }
+
+        return $buckets;
+    }
+
+    /**
+     * Next Horizon jobs list cursor: starting_at is a zero-based index into the Redis-backed list, not a unix timestamp.
+     *
+     * @param  int  $startingAt  The starting at.
+     * @param  array<int, mixed>  $batch  The batch.
+     */
+    protected function private__nextMetricsJobsStartingAt(int $startingAt, array $batch): int
+    {
+        $last = $batch[\array_key_last($batch)];
+        if (\is_array($last) && isset($last['index'])) {
+            return (int) $last['index'];
+        }
+
+        return \max(0, $startingAt + 1) + \count($batch) - 1;
+    }
+
+    /**
+     * Sum jobs by queue names using a precomputed lookup table.
+     *
+     * @param  array<int, string>  $queueNames
+     * @param  array<string, int>  $jobsByQueue
+     */
+    protected function private__sumJobsByQueueNames(array $queueNames, array $jobsByQueue): int
+    {
+        $jobs = 0;
+
+        foreach ($queueNames as $q) {
+            $jobs += $jobsByQueue[$q] ?? 0;
+        }
+
+        return $jobs;
     }
 }

--- a/app/Services/Metrics/JobsThroughputMetricsCalculator.php
+++ b/app/Services/Metrics/JobsThroughputMetricsCalculator.php
@@ -8,26 +8,18 @@ use Illuminate\Support\Collection;
 class JobsThroughputMetricsCalculator extends HorizonMetricsComputation
 {
     /**
-     * Get the number of jobs processed in the past minute.
+     * Get the number of failed jobs in the past seven days.
      *
      * @param  Service|null  $service  The service.
      */
-    public function getJobsPastMinute(?Service $service = null): int
+    public function getFailedPastSevenDays(?Service $service = null): int
     {
         if ($service !== null && $service->getBaseUrl()) {
             $response = $this->horizonApi->getStats($service);
             $data = $response['data'] ?? null;
 
-            if (($response['success'] ?? false) && \is_array($data)) {
-                $jobs_per_minute = isset($data['jobsPerMinute']) ? (float) $data['jobsPerMinute'] : 0.0;
-                if ($jobs_per_minute > 0) {
-                    return (int) \round($jobs_per_minute);
-                }
-                $recent = isset($data['recentJobs']) ? (int) $data['recentJobs'] : 0;
-                $period = isset($data['periods']['recentJobs']) ? (int) $data['periods']['recentJobs'] : 60;
-                if ($recent >= 0 && $period > 0) {
-                    return (int) \round($recent / $period);
-                }
+            if (($response['success'] ?? false) && \is_array($data) && isset($data['failedJobs'])) {
+                return (int) $data['failedJobs'];
             }
 
             return 0;
@@ -42,7 +34,14 @@ class JobsThroughputMetricsCalculator extends HorizonMetricsComputation
 
         $total = 0;
         foreach ($services as $svc) {
-            $total += $this->getJobsPastMinute($svc);
+            $response = $this->horizonApi->getStats($svc);
+            $data = $response['data'] ?? null;
+
+            if (! (($response['success'] ?? false) && \is_array($data) && isset($data['failedJobs']))) {
+                continue;
+            }
+
+            $total += (int) $data['failedJobs'];
         }
 
         return $total;
@@ -89,46 +88,6 @@ class JobsThroughputMetricsCalculator extends HorizonMetricsComputation
     }
 
     /**
-     * Get the number of failed jobs in the past seven days.
-     *
-     * @param  Service|null  $service  The service.
-     */
-    public function getFailedPastSevenDays(?Service $service = null): int
-    {
-        if ($service !== null && $service->getBaseUrl()) {
-            $response = $this->horizonApi->getStats($service);
-            $data = $response['data'] ?? null;
-
-            if (($response['success'] ?? false) && \is_array($data) && isset($data['failedJobs'])) {
-                return (int) $data['failedJobs'];
-            }
-
-            return 0;
-        }
-
-        /** @var Collection<int, Service> $services */
-        $services = $this->private__getServicesForMetrics();
-
-        if ($services->isEmpty()) {
-            return 0;
-        }
-
-        $total = 0;
-        foreach ($services as $svc) {
-            $response = $this->horizonApi->getStats($svc);
-            $data = $response['data'] ?? null;
-
-            if (! (($response['success'] ?? false) && \is_array($data) && isset($data['failedJobs']))) {
-                continue;
-            }
-
-            $total += (int) $data['failedJobs'];
-        }
-
-        return $total;
-    }
-
-    /**
      * Get jobs past hour per service using Horizon HTTP API stats.
      *
      * @return array{services: list<string>, jobsPastHour: list<int>}
@@ -159,5 +118,46 @@ class JobsThroughputMetricsCalculator extends HorizonMetricsComputation
         }
 
         return ['services' => $names, 'jobsPastHour' => $values];
+    }
+
+    /**
+     * Get the number of jobs processed in the past minute.
+     *
+     * @param  Service|null  $service  The service.
+     */
+    public function getJobsPastMinute(?Service $service = null): int
+    {
+        if ($service !== null && $service->getBaseUrl()) {
+            $response = $this->horizonApi->getStats($service);
+            $data = $response['data'] ?? null;
+
+            if (($response['success'] ?? false) && \is_array($data)) {
+                $jobs_per_minute = isset($data['jobsPerMinute']) ? (float) $data['jobsPerMinute'] : 0.0;
+                if ($jobs_per_minute > 0) {
+                    return (int) \round($jobs_per_minute);
+                }
+                $recent = isset($data['recentJobs']) ? (int) $data['recentJobs'] : 0;
+                $period = isset($data['periods']['recentJobs']) ? (int) $data['periods']['recentJobs'] : 60;
+                if ($recent >= 0 && $period > 0) {
+                    return (int) \round($recent / $period);
+                }
+            }
+
+            return 0;
+        }
+
+        /** @var Collection<int, Service> $services */
+        $services = $this->private__getServicesForMetrics();
+
+        if ($services->isEmpty()) {
+            return 0;
+        }
+
+        $total = 0;
+        foreach ($services as $svc) {
+            $total += $this->getJobsPastMinute($svc);
+        }
+
+        return $total;
     }
 }

--- a/app/Services/Metrics/WorkloadMetricsCalculator.php
+++ b/app/Services/Metrics/WorkloadMetricsCalculator.php
@@ -8,78 +8,6 @@ use App\Support\Horizon\QueueNameNormalizer;
 class WorkloadMetricsCalculator extends HorizonMetricsComputation
 {
     /**
-     * Get the current workload rows for a single service.
-     *
-     * @param  Service  $service  The service.
-     * @return array<int, array{queue: string, jobs: int, processes: int|null, wait: float|null}>
-     */
-    public function getWorkloadForService(Service $service): array
-    {
-        if ($service->getBaseUrl() === '') {
-            return [];
-        }
-
-        $response = $this->horizonApi->getWorkload($service);
-        $payload = $response['data'] ?? null;
-
-        if (! ($response['success'] ?? false) || $payload === null) {
-            return [];
-        }
-
-        $data = $payload['data'] ?? $payload['workload'] ?? null;
-        if ($data === null || ! \is_array($data)) {
-            if (\is_array($payload) && isset($payload[0]) && \is_array($payload[0]) && isset($payload[0]['name'])) {
-                $data = $payload;
-            } else {
-                return [];
-            }
-        }
-        if ($data === []) {
-            return [];
-        }
-
-        $rows = [];
-        foreach ($data as $row) {
-            if (! \is_array($row)) {
-                continue;
-            }
-
-            $queueName = '';
-            if (isset($row['name']) && (string) $row['name'] !== '') {
-                $queueName = (string) $row['name'];
-            }
-
-            $queueName = QueueNameNormalizer::normalize($queueName) ?? $queueName;
-            if ($queueName === '') {
-                continue;
-            }
-
-            $jobs = $row['length'] ?? $row['size'] ?? $row['pending'] ?? $row['jobs'] ?? 0;
-
-            $processes = null;
-            if (isset($row['processes']) && \is_numeric($row['processes'])) {
-                $processes = (int) $row['processes'];
-            }
-
-            $wait = null;
-            if (isset($row['wait']) && \is_numeric($row['wait'])) {
-                $wait = (float) $row['wait'];
-            }
-
-            $rows[] = [
-                'queue' => $queueName,
-                'jobs' => $jobs,
-                'processes' => $processes,
-                'wait' => $wait,
-            ];
-        }
-
-        \usort($rows, static fn (array $a, array $b): int => \strcmp($a['queue'], $b['queue']));
-
-        return $rows;
-    }
-
-    /**
      * Get supervisors aggregated across services (optionally filtered by service).
      *
      * @param  array<string, mixed>  $serviceScope  The service scope.
@@ -208,5 +136,77 @@ class WorkloadMetricsCalculator extends HorizonMetricsComputation
         }
 
         return $result;
+    }
+
+    /**
+     * Get the current workload rows for a single service.
+     *
+     * @param  Service  $service  The service.
+     * @return array<int, array{queue: string, jobs: int, processes: int|null, wait: float|null}>
+     */
+    public function getWorkloadForService(Service $service): array
+    {
+        if ($service->getBaseUrl() === '') {
+            return [];
+        }
+
+        $response = $this->horizonApi->getWorkload($service);
+        $payload = $response['data'] ?? null;
+
+        if (! ($response['success'] ?? false) || $payload === null) {
+            return [];
+        }
+
+        $data = $payload['data'] ?? $payload['workload'] ?? null;
+        if ($data === null || ! \is_array($data)) {
+            if (\is_array($payload) && isset($payload[0]) && \is_array($payload[0]) && isset($payload[0]['name'])) {
+                $data = $payload;
+            } else {
+                return [];
+            }
+        }
+        if ($data === []) {
+            return [];
+        }
+
+        $rows = [];
+        foreach ($data as $row) {
+            if (! \is_array($row)) {
+                continue;
+            }
+
+            $queueName = '';
+            if (isset($row['name']) && (string) $row['name'] !== '') {
+                $queueName = (string) $row['name'];
+            }
+
+            $queueName = QueueNameNormalizer::normalize($queueName) ?? $queueName;
+            if ($queueName === '') {
+                continue;
+            }
+
+            $jobs = $row['length'] ?? $row['size'] ?? $row['pending'] ?? $row['jobs'] ?? 0;
+
+            $processes = null;
+            if (isset($row['processes']) && \is_numeric($row['processes'])) {
+                $processes = (int) $row['processes'];
+            }
+
+            $wait = null;
+            if (isset($row['wait']) && \is_numeric($row['wait'])) {
+                $wait = (float) $row['wait'];
+            }
+
+            $rows[] = [
+                'queue' => $queueName,
+                'jobs' => $jobs,
+                'processes' => $processes,
+                'wait' => $wait,
+            ];
+        }
+
+        \usort($rows, static fn (array $a, array $b): int => \strcmp($a['queue'], $b['queue']));
+
+        return $rows;
     }
 }

--- a/app/Services/Notifiers/AbstractAlertNotifier.php
+++ b/app/Services/Notifiers/AbstractAlertNotifier.php
@@ -39,47 +39,6 @@ abstract class AbstractAlertNotifier implements AlertNotifier
     }
 
     /**
-     * Load failed job details from the Horizon API for the given service and UUIDs.
-     *
-     * @param  Service  $service  The service.
-     * @param  array<int, string>  $jobUuids  The job UUIDs.
-     * @return Collection<string, object{payload: array, name: string|null, queue: string|null, failed_at: Carbon|null, exception: string, attempts: int|null}>
-     */
-    protected function getJobs(Service $service, array $jobUuids): Collection
-    {
-        $jobs = \collect();
-        foreach ($jobUuids as $jobUuid) {
-            if ($jobUuid === '') {
-                continue;
-            }
-            $response = $this->horizonApi->getJob($service, $jobUuid);
-            $data = $response['data'] ?? null;
-            if (! ($response['success'] ?? false) || ! \is_array($data)) {
-                continue;
-            }
-            $failedAt = null;
-            if (isset($data['failed_at']) && (string) $data['failed_at'] !== '') {
-                try {
-                    $failedAt = Carbon::parse((string) $data['failed_at']);
-                } catch (\Throwable $e) {
-                    // leave null
-                }
-            }
-            $job = (object) [
-                'payload' => isset($data['payload']) ? $data['payload'] : [],
-                'name' => isset($data['name']) ? $data['name'] : null,
-                'queue' => isset($data['queue']) ? (string) $data['queue'] : null,
-                'failed_at' => $failedAt,
-                'exception' => isset($data['exception']) ? (string) $data['exception'] : '',
-                'attempts' => isset($data['attempts']) ? (int) $data['attempts'] : null,
-            ];
-            $jobs->put($jobUuid, $job);
-        }
-
-        return $jobs;
-    }
-
-    /**
      * Enrich events with job details from the Horizon API.
      *
      * @param  array<int, array{service_id: int, job_uuid: string|null, triggered_at: string}>  $events  The events.
@@ -134,6 +93,47 @@ abstract class AbstractAlertNotifier implements AlertNotifier
         }
 
         return $enriched;
+    }
+
+    /**
+     * Load failed job details from the Horizon API for the given service and UUIDs.
+     *
+     * @param  Service  $service  The service.
+     * @param  array<int, string>  $jobUuids  The job UUIDs.
+     * @return Collection<string, object{payload: array, name: string|null, queue: string|null, failed_at: Carbon|null, exception: string, attempts: int|null}>
+     */
+    protected function getJobs(Service $service, array $jobUuids): Collection
+    {
+        $jobs = \collect();
+        foreach ($jobUuids as $jobUuid) {
+            if ($jobUuid === '') {
+                continue;
+            }
+            $response = $this->horizonApi->getJob($service, $jobUuid);
+            $data = $response['data'] ?? null;
+            if (! ($response['success'] ?? false) || ! \is_array($data)) {
+                continue;
+            }
+            $failedAt = null;
+            if (isset($data['failed_at']) && (string) $data['failed_at'] !== '') {
+                try {
+                    $failedAt = Carbon::parse((string) $data['failed_at']);
+                } catch (\Throwable $e) {
+                    // leave null
+                }
+            }
+            $job = (object) [
+                'payload' => isset($data['payload']) ? $data['payload'] : [],
+                'name' => isset($data['name']) ? $data['name'] : null,
+                'queue' => isset($data['queue']) ? (string) $data['queue'] : null,
+                'failed_at' => $failedAt,
+                'exception' => isset($data['exception']) ? (string) $data['exception'] : '',
+                'attempts' => isset($data['attempts']) ? (int) $data['attempts'] : null,
+            ];
+            $jobs->put($jobUuid, $job);
+        }
+
+        return $jobs;
     }
 
     /**

--- a/app/Support/Horizon/JobCommandDataExtractor.php
+++ b/app/Support/Horizon/JobCommandDataExtractor.php
@@ -35,6 +35,28 @@ class JobCommandDataExtractor
     }
 
     /**
+     * Convert private/protected serialized property names to plain keys.
+     *
+     * @param  string|int  $key  The key.
+     */
+    private static function cleanPropertyKey(string|int $key): string|int
+    {
+        if (! \is_string($key) || $key === '') {
+            return $key;
+        }
+
+        if (\str_contains($key, "\0")) {
+            $parts = \explode("\0", $key);
+            $candidate = \end($parts);
+            if (\is_string($candidate) && $candidate !== '') {
+                return $candidate;
+            }
+        }
+
+        return $key;
+    }
+
+    /**
      * Normalize unserialized data to scalar/array values.
      *
      * @param  mixed  $value  The value.
@@ -69,27 +91,5 @@ class JobCommandDataExtractor
         }
 
         return (string) $value;
-    }
-
-    /**
-     * Convert private/protected serialized property names to plain keys.
-     *
-     * @param  string|int  $key  The key.
-     */
-    private static function cleanPropertyKey(string|int $key): string|int
-    {
-        if (! \is_string($key) || $key === '') {
-            return $key;
-        }
-
-        if (\str_contains($key, "\0")) {
-            $parts = \explode("\0", $key);
-            $candidate = \end($parts);
-            if (\is_string($candidate) && $candidate !== '') {
-                return $candidate;
-            }
-        }
-
-        return $key;
     }
 }

--- a/app/Support/Horizon/JobRuntimeHelper.php
+++ b/app/Support/Horizon/JobRuntimeHelper.php
@@ -7,35 +7,17 @@ use Carbon\Carbon;
 class JobRuntimeHelper
 {
     /**
-     * Parse a Horizon timestamp value into Carbon.
+     * Human-readable runtime in seconds (e.g. "0.08 s", "1.23 s").
      *
-     * @param  mixed  $value  The value.
+     * @param  float|null  $seconds  The seconds.
      */
-    public static function parseJobTimestamp(mixed $value): ?Carbon
+    public static function getFormattedRuntime(?float $seconds): ?string
     {
-        if ($value === null || $value === '' || $value === false) {
+        if ($seconds === null) {
             return null;
         }
 
-        if ($value instanceof Carbon) {
-            return $value;
-        }
-
-        if (\is_numeric($value)) {
-            $seconds = (float) $value;
-
-            return Carbon::createFromTimestampMs((int) \round($seconds * 1000));
-        }
-
-        if (\is_string($value)) {
-            try {
-                return Carbon::parse($value);
-            } catch (\Throwable $e) {
-                return null;
-            }
-        }
-
-        return null;
+        return \number_format($seconds, 2).' s';
     }
 
     /**
@@ -66,20 +48,6 @@ class JobRuntimeHelper
     }
 
     /**
-     * Human-readable runtime in seconds (e.g. "0.08 s", "1.23 s").
-     *
-     * @param  float|null  $seconds  The seconds.
-     */
-    public static function getFormattedRuntime(?float $seconds): ?string
-    {
-        if ($seconds === null) {
-            return null;
-        }
-
-        return \number_format($seconds, 2).' s';
-    }
-
-    /**
      * Normalise processed/failed timestamps according to job status.
      *
      * - For "processed" jobs, failed_at is cleared.
@@ -100,6 +68,38 @@ class JobRuntimeHelper
             $processedAt = null;
             $failedAt = null;
         }
+    }
+
+    /**
+     * Parse a Horizon timestamp value into Carbon.
+     *
+     * @param  mixed  $value  The value.
+     */
+    public static function parseJobTimestamp(mixed $value): ?Carbon
+    {
+        if ($value === null || $value === '' || $value === false) {
+            return null;
+        }
+
+        if ($value instanceof Carbon) {
+            return $value;
+        }
+
+        if (\is_numeric($value)) {
+            $seconds = (float) $value;
+
+            return Carbon::createFromTimestampMs((int) \round($seconds * 1000));
+        }
+
+        if (\is_string($value)) {
+            try {
+                return Carbon::parse($value);
+            } catch (\Throwable $e) {
+                return null;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/resources/js/charts/metrics-charts.js
+++ b/resources/js/charts/metrics-charts.js
@@ -12,62 +12,6 @@ export function getChartColors() {
 }
 
 /**
- * Get the HSL value of a CSS variable.
- * @param {string} varName
- * @returns {string}
- */
-function getCssHsl(varName) {
-    var val = getComputedStyle(document.documentElement).getPropertyValue(varName).trim();
-    if (!val) return null;
-    return 'hsl(' + val.replace(/\s+/g, ', ') + ')';
-}
-
-/**
- * Read legend series visibility from an existing chart (ECharts toggles this when the user clicks the legend).
- * @param {object} chart
- * @returns {object|null} Map of series name -> selected boolean
- */
-function getLegendSelectedFromChart(chart) {
-    try {
-        var opt = chart.getOption();
-        if (!opt || opt.legend === undefined) return null;
-        var legends = Array.isArray(opt.legend) ? opt.legend : [opt.legend];
-        for (var i = 0; i < legends.length; i++) {
-            var leg = legends[i];
-            if (leg && leg.selected && typeof leg.selected === 'object' && Object.keys(leg.selected).length) {
-                return Object.assign({}, leg.selected);
-            }
-        }
-        return null;
-    } catch (e) {
-        return null;
-    }
-}
-
-/**
- * Merge prior legend visibility into new options so hot reload / data refresh keeps user filters.
- * @param {object} options
- * @param {object} previousSelected
- * @returns {void}
- */
-function mergeLegendSelectedIntoOptions(options, previousSelected) {
-    if (!previousSelected || !options || !options.legend) return;
-    var leg = options.legend;
-    var data = leg.data;
-    if (!Array.isArray(data) || data.length === 0) return;
-    var selected = {};
-    for (var i = 0; i < data.length; i++) {
-        var name = data[i];
-        if (Object.prototype.hasOwnProperty.call(previousSelected, name)) {
-            selected[name] = !!previousSelected[name];
-        } else {
-            selected[name] = true;
-        }
-    }
-    options.legend = Object.assign({}, leg, { selected: selected });
-}
-
-/**
  * Apply the chart options.
  * @param {Element} el
  * @param {object} options
@@ -139,4 +83,57 @@ export function buildJobsVolumeLast24hOptions(jobsVolumeLast24h, c) {
             },
         ],
     };
+}
+
+/**
+ * Get the HSL value of a CSS variable.
+ * @param {string} varName
+ * @returns {string}
+ */
+function getCssHsl(varName) {
+    var val = getComputedStyle(document.documentElement).getPropertyValue(varName).trim();
+    if (!val) return null;
+    return 'hsl(' + val.replace(/\s+/g, ', ') + ')';
+}
+
+/**
+ * Read legend series visibility from an existing chart (ECharts toggles this when the user clicks the legend).
+ * @param {object} chart
+ * @returns {object|null} Map of series name -> selected boolean
+ */
+function getLegendSelectedFromChart(chart) {
+    try {
+        var opt = chart.getOption();
+        if (!opt || opt.legend === undefined) return null;
+        var legends = Array.isArray(opt.legend) ? opt.legend : [opt.legend];
+        for (var i = 0; i < legends.length; i++) {
+            var leg = legends[i];
+            if (leg && leg.selected && typeof leg.selected === 'object' && Object.keys(leg.selected).length) {
+                return Object.assign({}, leg.selected);
+            }
+        }
+        return null;
+    } catch (e) {
+        return null;
+    }
+}
+
+/**
+ * Merge prior legend visibility into new options so hot reload / data refresh keeps user filters.
+ * @param {object} options
+ * @param {object} previousSelected
+ * @returns {void}
+ */
+function mergeLegendSelectedIntoOptions(options, previousSelected) {
+    if (!previousSelected || !options || !options.legend || !Array.isArray(options.legend.data) || options.legend.data.length === 0) return;
+    var selected = {};
+    for (var i = 0; i < options.legend.data.length; i++) {
+        var name = options.legend.data[i];
+        if (Object.prototype.hasOwnProperty.call(previousSelected, name)) {
+            selected[name] = !!previousSelected[name];
+        } else {
+            selected[name] = true;
+        }
+    }
+    options.legend = Object.assign({}, options.legend, { selected: selected });
 }

--- a/tests/Feature/TurboFormResponseTest.php
+++ b/tests/Feature/TurboFormResponseTest.php
@@ -19,30 +19,6 @@ class TurboFormResponseTest extends TestCase
         $this->withoutMiddleware(ValidateCsrfToken::class);
     }
 
-    public function test_service_store_returns_303_for_turbo_request(): void
-    {
-        $response = $this->post(route('horizon.services.store'), [
-            'name' => 'Test Service',
-            'base_url' => 'https://example.com',
-        ], [
-            'Accept' => Turbo::TURBO_STREAM_FORMAT,
-        ]);
-
-        $response->assertStatus(303);
-        $response->assertRedirect(route('horizon.services.index'));
-    }
-
-    public function test_service_store_returns_302_for_non_turbo_request(): void
-    {
-        $response = $this->post(route('horizon.services.store'), [
-            'name' => 'Test Service Non-Turbo',
-            'base_url' => 'https://example.com',
-        ]);
-
-        $response->assertStatus(302);
-        $response->assertRedirect(route('horizon.services.index'));
-    }
-
     public function test_service_destroy_returns_303_for_turbo_request(): void
     {
         $service = Service::create([
@@ -56,5 +32,29 @@ class TurboFormResponseTest extends TestCase
         ]);
 
         $response->assertStatus(303);
+    }
+
+    public function test_service_store_returns_302_for_non_turbo_request(): void
+    {
+        $response = $this->post(route('horizon.services.store'), [
+            'name' => 'Test Service Non-Turbo',
+            'base_url' => 'https://example.com',
+        ]);
+
+        $response->assertStatus(302);
+        $response->assertRedirect(route('horizon.services.index'));
+    }
+
+    public function test_service_store_returns_303_for_turbo_request(): void
+    {
+        $response = $this->post(route('horizon.services.store'), [
+            'name' => 'Test Service',
+            'base_url' => 'https://example.com',
+        ], [
+            'Accept' => Turbo::TURBO_STREAM_FORMAT,
+        ]);
+
+        $response->assertStatus(303);
+        $response->assertRedirect(route('horizon.services.index'));
     }
 }

--- a/tests/Feature/TurboStreamSseTest.php
+++ b/tests/Feature/TurboStreamSseTest.php
@@ -12,73 +12,6 @@ class TurboStreamSseTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_streams_metrics_returns_sse_content_type(): void
-    {
-        $response = $this->get(route('horizon.streams.metrics'));
-
-        $this->assertStringStartsWith('text/event-stream', $response->headers->get('Content-Type'));
-    }
-
-    public function test_streams_dashboard_returns_sse_content_type(): void
-    {
-        $response = $this->get(route('horizon.streams.dashboard'));
-
-        $this->assertStringStartsWith('text/event-stream', $response->headers->get('Content-Type'));
-    }
-
-    public function test_streams_service_show_returns_sse_content_type(): void
-    {
-        $service = Service::create([
-            'name' => 'test-svc',
-            'base_url' => '',
-            'status' => 'online',
-        ]);
-
-        $response = $this->get(route('horizon.streams.service-show', ['service' => $service->id]));
-
-        $this->assertStringStartsWith('text/event-stream', $response->headers->get('Content-Type'));
-    }
-
-    public function test_build_metrics_streams_returns_granular_targets(): void
-    {
-        $controller = $this->app->make(HorizonStreamsController::class);
-
-        $reflection = new \ReflectionMethod($controller, 'private__buildMetricsStreams');
-        $reflection->setAccessible(true);
-
-        $result = $reflection->invoke($controller, '');
-
-        $this->assertNotNull($result);
-        $this->assertStringContainsString('target="metrics-value-jobs-minute"', $result);
-        $this->assertStringContainsString('target="metrics-value-jobs-hour"', $result);
-        $this->assertStringContainsString('target="metrics-value-failed-seven"', $result);
-        $this->assertStringContainsString('target="metrics-chart-data"', $result);
-        $this->assertStringContainsString('target="metrics-workload-body" method="morph"', $result);
-        $this->assertStringContainsString('target="metrics-supervisors-body" method="morph"', $result);
-        $this->assertStringContainsString('action="update"', $result);
-        $this->assertStringContainsString('action="replace"', $result);
-    }
-
-    public function test_build_queues_streams_returns_tbody_update(): void
-    {
-        Service::create([
-            'name' => 'test-svc',
-            'base_url' => '',
-            'status' => 'online',
-        ]);
-
-        $controller = $this->app->make(HorizonStreamsController::class);
-
-        $reflection = new \ReflectionMethod($controller, 'private__buildQueuesStreams');
-        $reflection->setAccessible(true);
-
-        $result = $reflection->invoke($controller, '');
-
-        $this->assertNotNull($result);
-        $this->assertStringContainsString('target="turbo-tbody-horizon-queue-list" method="morph"', $result);
-        $this->assertStringContainsString('action="update"', $result);
-    }
-
     public function test_build_alerts_streams_returns_tbody_update(): void
     {
         $controller = $this->app->make(HorizonStreamsController::class);
@@ -91,59 +24,6 @@ class TurboStreamSseTest extends TestCase
         $this->assertNotNull($result);
         $this->assertStringContainsString('target="turbo-tbody-horizon-alerts-list" method="morph"', $result);
         $this->assertStringContainsString('action="update"', $result);
-    }
-
-    public function test_build_services_streams_returns_tbody_morph_update(): void
-    {
-        Service::create([
-            'name' => 'test-svc-stream',
-            'base_url' => '',
-            'status' => 'online',
-        ]);
-
-        $controller = $this->app->make(HorizonStreamsController::class);
-
-        $reflection = new \ReflectionMethod($controller, 'private__buildServicesStreams');
-        $reflection->setAccessible(true);
-
-        $result = $reflection->invoke($controller);
-
-        $this->assertNotNull($result);
-        $this->assertStringContainsString('target="turbo-tbody-horizon-service-list" method="morph"', $result);
-        $this->assertStringContainsString('action="update"', $result);
-    }
-
-    public function test_services_index_marks_stream_patch_children_on_list_container(): void
-    {
-        Service::create([
-            'name' => 'merge-markup-svc',
-            'base_url' => '',
-            'status' => 'online',
-        ]);
-
-        $response = $this->get(route('horizon.services.index'));
-
-        $response->assertOk();
-        $html = (string) $response->getContent();
-        $this->assertStringContainsString('data-turbo-stream-patch-children="true"', $html);
-        $this->assertStringContainsString('data-stream-row-id="svc-', $html);
-    }
-
-    public function test_build_jobs_index_streams_returns_per_section_tbody_updates(): void
-    {
-        $controller = $this->app->make(HorizonStreamsController::class);
-
-        $reflection = new \ReflectionMethod($controller, 'private__buildJobsIndexStreams');
-        $reflection->setAccessible(true);
-
-        $result = $reflection->invoke($controller, '');
-
-        $this->assertNotNull($result);
-        $this->assertStringContainsString('target="turbo-tbody-horizon-job-list-processing" method="morph"', $result);
-        $this->assertStringContainsString('target="job-count-horizon-job-list-processing"', $result);
-        $this->assertStringContainsString('target="job-pagination-horizon-job-list-processing"', $result);
-        $this->assertStringContainsString('action="update"', $result);
-        $this->assertStringNotContainsString('target="horizon-jobs-stack"', $result);
     }
 
     public function test_build_dashboard_streams_returns_expected_targets(): void
@@ -200,6 +80,106 @@ class TurboStreamSseTest extends TestCase
         $this->assertStringContainsString('action="update"', $result);
     }
 
+    public function test_build_jobs_index_streams_returns_per_section_tbody_updates(): void
+    {
+        $controller = $this->app->make(HorizonStreamsController::class);
+
+        $reflection = new \ReflectionMethod($controller, 'private__buildJobsIndexStreams');
+        $reflection->setAccessible(true);
+
+        $result = $reflection->invoke($controller, '');
+
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('target="turbo-tbody-horizon-job-list-processing" method="morph"', $result);
+        $this->assertStringContainsString('target="job-count-horizon-job-list-processing"', $result);
+        $this->assertStringContainsString('target="job-pagination-horizon-job-list-processing"', $result);
+        $this->assertStringContainsString('action="update"', $result);
+        $this->assertStringNotContainsString('target="horizon-jobs-stack"', $result);
+    }
+
+    public function test_build_metrics_streams_returns_granular_targets(): void
+    {
+        $controller = $this->app->make(HorizonStreamsController::class);
+
+        $reflection = new \ReflectionMethod($controller, 'private__buildMetricsStreams');
+        $reflection->setAccessible(true);
+
+        $result = $reflection->invoke($controller, '');
+
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('target="metrics-value-jobs-minute"', $result);
+        $this->assertStringContainsString('target="metrics-value-jobs-hour"', $result);
+        $this->assertStringContainsString('target="metrics-value-failed-seven"', $result);
+        $this->assertStringContainsString('target="metrics-chart-data"', $result);
+        $this->assertStringContainsString('target="metrics-workload-body" method="morph"', $result);
+        $this->assertStringContainsString('target="metrics-supervisors-body" method="morph"', $result);
+        $this->assertStringContainsString('action="update"', $result);
+        $this->assertStringContainsString('action="replace"', $result);
+    }
+
+    public function test_build_queues_streams_returns_tbody_update(): void
+    {
+        Service::create([
+            'name' => 'test-svc',
+            'base_url' => '',
+            'status' => 'online',
+        ]);
+
+        $controller = $this->app->make(HorizonStreamsController::class);
+
+        $reflection = new \ReflectionMethod($controller, 'private__buildQueuesStreams');
+        $reflection->setAccessible(true);
+
+        $result = $reflection->invoke($controller, '');
+
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('target="turbo-tbody-horizon-queue-list" method="morph"', $result);
+        $this->assertStringContainsString('action="update"', $result);
+    }
+
+    public function test_build_services_streams_returns_tbody_morph_update(): void
+    {
+        Service::create([
+            'name' => 'test-svc-stream',
+            'base_url' => '',
+            'status' => 'online',
+        ]);
+
+        $controller = $this->app->make(HorizonStreamsController::class);
+
+        $reflection = new \ReflectionMethod($controller, 'private__buildServicesStreams');
+        $reflection->setAccessible(true);
+
+        $result = $reflection->invoke($controller);
+
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('target="turbo-tbody-horizon-service-list" method="morph"', $result);
+        $this->assertStringContainsString('action="update"', $result);
+    }
+
+    public function test_services_index_marks_stream_patch_children_on_list_container(): void
+    {
+        Service::create([
+            'name' => 'merge-markup-svc',
+            'base_url' => '',
+            'status' => 'online',
+        ]);
+
+        $response = $this->get(route('horizon.services.index'));
+
+        $response->assertOk();
+        $html = (string) $response->getContent();
+        $this->assertStringContainsString('data-turbo-stream-patch-children="true"', $html);
+        $this->assertStringContainsString('data-stream-row-id="svc-', $html);
+    }
+
+    public function test_streams_dashboard_returns_sse_content_type(): void
+    {
+        $response = $this->get(route('horizon.streams.dashboard'));
+
+        $this->assertStringStartsWith('text/event-stream', $response->headers->get('Content-Type'));
+    }
+
     public function test_streams_job_show_returns_sse_content_type_when_resolvable(): void
     {
         $service = Service::create([
@@ -226,6 +206,26 @@ class TurboStreamSseTest extends TestCase
         });
 
         $response = $this->get('/horizon/streams/horizon/jobs/'.$jobUuid.'?service_id='.$service->id);
+
+        $this->assertStringStartsWith('text/event-stream', $response->headers->get('Content-Type'));
+    }
+
+    public function test_streams_metrics_returns_sse_content_type(): void
+    {
+        $response = $this->get(route('horizon.streams.metrics'));
+
+        $this->assertStringStartsWith('text/event-stream', $response->headers->get('Content-Type'));
+    }
+
+    public function test_streams_service_show_returns_sse_content_type(): void
+    {
+        $service = Service::create([
+            'name' => 'test-svc',
+            'base_url' => '',
+            'status' => 'online',
+        ]);
+
+        $response = $this->get(route('horizon.streams.service-show', ['service' => $service->id]));
 
         $this->assertStringStartsWith('text/event-stream', $response->headers->get('Content-Type'));
     }

--- a/tests/Unit/AgentProxyServiceTest.php
+++ b/tests/Unit/AgentProxyServiceTest.php
@@ -12,6 +12,55 @@ class AgentProxyServiceTest extends TestCase
 {
     use RefreshDatabase;
 
+    public function test_get_failed_jobs_surfaces_json_message_from_error_response(): void
+    {
+        Http::fake([
+            '*' => Http::response('{"message":"Rate limited"}', 429, ['Content-Type' => 'application/json']),
+        ]);
+
+        \config()->set('horizonhub.horizon_http_retry', [
+            'times' => 1,
+            'sleep_ms' => 100,
+            'retry_on_status' => [429, 502, 503, 504],
+        ]);
+
+        $service = Service::create([
+            'name' => 'proxy-err',
+            'base_url' => 'https://proxy-err.test',
+            'status' => 'online',
+        ]);
+
+        \config()->set('horizonhub.horizon_paths.api', '/horizon/api');
+        \config()->set('horizonhub.horizon_paths.failed_jobs', '/jobs/failed');
+
+        $proxy = new HorizonApiProxyService;
+        $result = $proxy->getFailedJobs($service, ['starting_at' => 0, 'limit' => 5]);
+
+        $this->assertFalse($result['success']);
+        $this->assertSame(429, $result['status'] ?? null);
+        $this->assertSame('Rate limited', $result['message'] ?? null);
+    }
+
+    public function test_ping_returns_error_when_service_has_no_base_url(): void
+    {
+        Http::fake();
+
+        $service = Service::create([
+            'name' => 'no-base',
+            'base_url' => '',
+            'status' => 'online',
+        ]);
+
+        \config()->set('horizonhub.horizon_paths.ping', '/stats');
+
+        $proxy = new HorizonApiProxyService;
+        $result = $proxy->ping($service);
+
+        $this->assertFalse($result['success']);
+        $this->assertSame(400, $result['status'] ?? null);
+        $this->assertStringContainsString('base_url', (string) ($result['message'] ?? ''));
+    }
+
     public function test_retry_job_calls_horizon_api_and_returns_success(): void
     {
         $capturedRetryRequest = null;
@@ -49,54 +98,5 @@ class AgentProxyServiceTest extends TestCase
         $this->assertTrue($result['success']);
         $this->assertNotNull($capturedRetryRequest);
         $this->assertSame('https://example.test/horizon/api/jobs/retry/job-uuid-1', $capturedRetryRequest->url());
-    }
-
-    public function test_ping_returns_error_when_service_has_no_base_url(): void
-    {
-        Http::fake();
-
-        $service = Service::create([
-            'name' => 'no-base',
-            'base_url' => '',
-            'status' => 'online',
-        ]);
-
-        \config()->set('horizonhub.horizon_paths.ping', '/stats');
-
-        $proxy = new HorizonApiProxyService;
-        $result = $proxy->ping($service);
-
-        $this->assertFalse($result['success']);
-        $this->assertSame(400, $result['status'] ?? null);
-        $this->assertStringContainsString('base_url', (string) ($result['message'] ?? ''));
-    }
-
-    public function test_get_failed_jobs_surfaces_json_message_from_error_response(): void
-    {
-        Http::fake([
-            '*' => Http::response('{"message":"Rate limited"}', 429, ['Content-Type' => 'application/json']),
-        ]);
-
-        \config()->set('horizonhub.horizon_http_retry', [
-            'times' => 1,
-            'sleep_ms' => 100,
-            'retry_on_status' => [429, 502, 503, 504],
-        ]);
-
-        $service = Service::create([
-            'name' => 'proxy-err',
-            'base_url' => 'https://proxy-err.test',
-            'status' => 'online',
-        ]);
-
-        \config()->set('horizonhub.horizon_paths.api', '/horizon/api');
-        \config()->set('horizonhub.horizon_paths.failed_jobs', '/jobs/failed');
-
-        $proxy = new HorizonApiProxyService;
-        $result = $proxy->getFailedJobs($service, ['starting_at' => 0, 'limit' => 5]);
-
-        $this->assertFalse($result['success']);
-        $this->assertSame(429, $result['status'] ?? null);
-        $this->assertSame('Rate limited', $result['message'] ?? null);
     }
 }

--- a/tests/Unit/AlertEngineTest.php
+++ b/tests/Unit/AlertEngineTest.php
@@ -15,38 +15,6 @@ class AlertEngineTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_evaluate_after_event_does_not_call_evaluator_for_scheduled_only_rules(): void
-    {
-        $evaluator = $this->createMock(AlertRuleEvaluator::class);
-        $evaluator->expects($this->never())->method('evaluateWithTriggeringJobs');
-
-        $batch = $this->createMock(AlertBatchStore::class);
-        $batch->method('getPending')->willReturn([]);
-        $batch->method('shouldSendNow')->willReturn(false);
-
-        $dispatcher = $this->createMock(AlertNotificationDispatcher::class);
-        $dispatcher->expects($this->never())->method('dispatch');
-
-        $service = Service::create([
-            'name' => 'alert-svc',
-            'base_url' => 'https://alerts.test',
-            'status' => 'online',
-        ]);
-
-        Alert::query()->create([
-            'name' => 'queue blocked',
-            'service_ids' => [],
-            'rule_type' => Alert::RULE_QUEUE_BLOCKED,
-            'threshold' => null,
-            'queue' => null,
-            'job_type' => null,
-            'enabled' => true,
-        ]);
-
-        $engine = new AlertEngine($evaluator, $batch, $dispatcher);
-        $engine->evaluateAfterEvent((int) $service->id, 'JobFailed', 'job-uuid');
-    }
-
     public function test_evaluate_after_event_calls_evaluator_for_job_failed_rule(): void
     {
         $evaluator = $this->createMock(AlertRuleEvaluator::class);
@@ -71,6 +39,38 @@ class AlertEngineTest extends TestCase
             'name' => 'failure count',
             'service_ids' => [],
             'rule_type' => Alert::RULE_FAILURE_COUNT,
+            'threshold' => null,
+            'queue' => null,
+            'job_type' => null,
+            'enabled' => true,
+        ]);
+
+        $engine = new AlertEngine($evaluator, $batch, $dispatcher);
+        $engine->evaluateAfterEvent((int) $service->id, 'JobFailed', 'job-uuid');
+    }
+
+    public function test_evaluate_after_event_does_not_call_evaluator_for_scheduled_only_rules(): void
+    {
+        $evaluator = $this->createMock(AlertRuleEvaluator::class);
+        $evaluator->expects($this->never())->method('evaluateWithTriggeringJobs');
+
+        $batch = $this->createMock(AlertBatchStore::class);
+        $batch->method('getPending')->willReturn([]);
+        $batch->method('shouldSendNow')->willReturn(false);
+
+        $dispatcher = $this->createMock(AlertNotificationDispatcher::class);
+        $dispatcher->expects($this->never())->method('dispatch');
+
+        $service = Service::create([
+            'name' => 'alert-svc',
+            'base_url' => 'https://alerts.test',
+            'status' => 'online',
+        ]);
+
+        Alert::query()->create([
+            'name' => 'queue blocked',
+            'service_ids' => [],
+            'rule_type' => Alert::RULE_QUEUE_BLOCKED,
             'threshold' => null,
             'queue' => null,
             'job_type' => null,

--- a/tests/Unit/DatetimeBoundaryParserTest.php
+++ b/tests/Unit/DatetimeBoundaryParserTest.php
@@ -9,19 +9,19 @@ use Tests\TestCase;
 class DatetimeBoundaryParserTest extends TestCase
 {
     #[Test]
+    public function empty_strings_return_null(): void
+    {
+        $this->assertNull(DatetimeBoundaryParser::parseLower(''));
+        $this->assertNull(DatetimeBoundaryParser::parseLower(null));
+        $this->assertNull(DatetimeBoundaryParser::parseUpper('   '));
+    }
+
+    #[Test]
     public function parse_lower_date_only_is_start_of_day(): void
     {
         $c = DatetimeBoundaryParser::parseLower('2026-01-10');
         $this->assertNotNull($c);
         $this->assertSame('2026-01-10 00:00:00', $c->format('Y-m-d H:i:s'));
-    }
-
-    #[Test]
-    public function parse_upper_date_only_is_end_of_day(): void
-    {
-        $c = DatetimeBoundaryParser::parseUpper('2026-01-10');
-        $this->assertNotNull($c);
-        $this->assertSame('2026-01-10 23:59:59', $c->format('Y-m-d H:i:s'));
     }
 
     #[Test]
@@ -33,18 +33,18 @@ class DatetimeBoundaryParserTest extends TestCase
     }
 
     #[Test]
+    public function parse_upper_date_only_is_end_of_day(): void
+    {
+        $c = DatetimeBoundaryParser::parseUpper('2026-01-10');
+        $this->assertNotNull($c);
+        $this->assertSame('2026-01-10 23:59:59', $c->format('Y-m-d H:i:s'));
+    }
+
+    #[Test]
     public function parse_upper_datetime_preserves_instant(): void
     {
         $c = DatetimeBoundaryParser::parseUpper('2026-01-10T14:30');
         $this->assertNotNull($c);
         $this->assertSame('2026-01-10 14:30:00', $c->format('Y-m-d H:i:s'));
-    }
-
-    #[Test]
-    public function empty_strings_return_null(): void
-    {
-        $this->assertNull(DatetimeBoundaryParser::parseLower(''));
-        $this->assertNull(DatetimeBoundaryParser::parseLower(null));
-        $this->assertNull(DatetimeBoundaryParser::parseUpper('   '));
     }
 }

--- a/tests/Unit/HorizonApiProxyServiceTest.php
+++ b/tests/Unit/HorizonApiProxyServiceTest.php
@@ -12,6 +12,68 @@ class HorizonApiProxyServiceTest extends TestCase
 {
     use RefreshDatabase;
 
+    public function test_get_failed_jobs_retries_on_429_then_succeeds(): void
+    {
+        $calls = 0;
+        Http::fake(function () use (&$calls) {
+            $calls++;
+            if ($calls < 3) {
+                return Http::response(['message' => 'Rate limited'], 429);
+            }
+
+            return Http::response(['data' => ['jobs' => []]], 200);
+        });
+
+        \config()->set('horizonhub.horizon_http_retry', [
+            'times' => 3,
+            'sleep_ms' => 0,
+            'retry_on_status' => [429, 502, 503, 504],
+        ]);
+        \config()->set('horizonhub.horizon_paths.api', '/horizon/api');
+        \config()->set('horizonhub.horizon_paths.failed_jobs', '/jobs/failed');
+
+        $service = Service::create([
+            'name' => 'svc-retry-429',
+            'base_url' => 'https://service-retry-429.test',
+            'status' => 'online',
+        ]);
+
+        $proxy = new HorizonApiProxyService;
+        $result = $proxy->getFailedJobs($service, ['starting_at' => 0, 'limit' => 10]);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame(3, $calls);
+        $this->assertArrayHasKey('data', $result);
+    }
+
+    public function test_get_failed_jobs_returns_trimmed_plain_text_error_message(): void
+    {
+        Http::fake([
+            '*' => Http::response('Rate limited by upstream', 429, ['Content-Type' => 'text/plain']),
+        ]);
+
+        \config()->set('horizonhub.horizon_http_retry', [
+            'times' => 1,
+            'sleep_ms' => 100,
+            'retry_on_status' => [429, 502, 503, 504],
+        ]);
+        \config()->set('horizonhub.horizon_paths.api', '/horizon/api');
+        \config()->set('horizonhub.horizon_paths.failed_jobs', '/jobs/failed');
+
+        $service = Service::create([
+            'name' => 'svc-plain-text-error',
+            'base_url' => 'https://service-plain-error.test',
+            'status' => 'online',
+        ]);
+
+        $proxy = new HorizonApiProxyService;
+        $result = $proxy->getFailedJobs($service, ['starting_at' => 0, 'limit' => 10]);
+
+        $this->assertFalse($result['success']);
+        $this->assertSame(429, $result['status'] ?? null);
+        $this->assertSame('Rate limited by upstream', $result['message'] ?? null);
+    }
+
     public function test_get_workload_retries_with_dashboard_session_after_unauthorized_response(): void
     {
         $apiCalls = 0;
@@ -55,6 +117,54 @@ class HorizonApiProxyServiceTest extends TestCase
         $this->assertSame('offline', $service->fresh()->status);
     }
 
+    public function test_ping_returns_502_on_http_exception(): void
+    {
+        Http::fake(function () {
+            throw new \RuntimeException('network down');
+        });
+
+        \config()->set('horizonhub.horizon_paths.api', '/horizon/api');
+        \config()->set('horizonhub.horizon_paths.ping', '/stats');
+
+        $service = Service::create([
+            'name' => 'svc-exception',
+            'base_url' => 'https://service-exception.test',
+            'status' => 'offline',
+        ]);
+
+        $proxy = new HorizonApiProxyService;
+        $result = $proxy->ping($service);
+
+        $this->assertFalse($result['success']);
+        $this->assertSame(502, $result['status'] ?? null);
+        $this->assertSame('network down', $result['message'] ?? null);
+    }
+
+    public function test_ping_success_updates_last_seen_at_and_status(): void
+    {
+        Http::fake([
+            '*' => Http::response(['status' => 'ok'], 200),
+        ]);
+
+        \config()->set('horizonhub.horizon_paths.api', '/horizon/api');
+        \config()->set('horizonhub.horizon_paths.ping', '/stats');
+
+        $service = Service::create([
+            'name' => 'svc-heartbeat',
+            'base_url' => 'https://service-heartbeat.test',
+            'status' => 'offline',
+            'last_seen_at' => null,
+        ]);
+
+        $proxy = new HorizonApiProxyService;
+        $result = $proxy->ping($service);
+
+        $freshService = $service->fresh();
+        $this->assertTrue($result['success']);
+        $this->assertSame('online', $freshService->status);
+        $this->assertNotNull($freshService->last_seen_at);
+    }
+
     public function test_retry_job_retries_once_after_419_response(): void
     {
         $retryCalls = 0;
@@ -95,115 +205,5 @@ class HorizonApiProxyServiceTest extends TestCase
         $this->assertTrue($result['success']);
         $this->assertSame(2, $retryCalls);
         $this->assertSame(2, $dashboardCalls);
-    }
-
-    public function test_ping_returns_502_on_http_exception(): void
-    {
-        Http::fake(function () {
-            throw new \RuntimeException('network down');
-        });
-
-        \config()->set('horizonhub.horizon_paths.api', '/horizon/api');
-        \config()->set('horizonhub.horizon_paths.ping', '/stats');
-
-        $service = Service::create([
-            'name' => 'svc-exception',
-            'base_url' => 'https://service-exception.test',
-            'status' => 'offline',
-        ]);
-
-        $proxy = new HorizonApiProxyService;
-        $result = $proxy->ping($service);
-
-        $this->assertFalse($result['success']);
-        $this->assertSame(502, $result['status'] ?? null);
-        $this->assertSame('network down', $result['message'] ?? null);
-    }
-
-    public function test_get_failed_jobs_returns_trimmed_plain_text_error_message(): void
-    {
-        Http::fake([
-            '*' => Http::response('Rate limited by upstream', 429, ['Content-Type' => 'text/plain']),
-        ]);
-
-        \config()->set('horizonhub.horizon_http_retry', [
-            'times' => 1,
-            'sleep_ms' => 100,
-            'retry_on_status' => [429, 502, 503, 504],
-        ]);
-        \config()->set('horizonhub.horizon_paths.api', '/horizon/api');
-        \config()->set('horizonhub.horizon_paths.failed_jobs', '/jobs/failed');
-
-        $service = Service::create([
-            'name' => 'svc-plain-text-error',
-            'base_url' => 'https://service-plain-error.test',
-            'status' => 'online',
-        ]);
-
-        $proxy = new HorizonApiProxyService;
-        $result = $proxy->getFailedJobs($service, ['starting_at' => 0, 'limit' => 10]);
-
-        $this->assertFalse($result['success']);
-        $this->assertSame(429, $result['status'] ?? null);
-        $this->assertSame('Rate limited by upstream', $result['message'] ?? null);
-    }
-
-    public function test_ping_success_updates_last_seen_at_and_status(): void
-    {
-        Http::fake([
-            '*' => Http::response(['status' => 'ok'], 200),
-        ]);
-
-        \config()->set('horizonhub.horizon_paths.api', '/horizon/api');
-        \config()->set('horizonhub.horizon_paths.ping', '/stats');
-
-        $service = Service::create([
-            'name' => 'svc-heartbeat',
-            'base_url' => 'https://service-heartbeat.test',
-            'status' => 'offline',
-            'last_seen_at' => null,
-        ]);
-
-        $proxy = new HorizonApiProxyService;
-        $result = $proxy->ping($service);
-
-        $freshService = $service->fresh();
-        $this->assertTrue($result['success']);
-        $this->assertSame('online', $freshService->status);
-        $this->assertNotNull($freshService->last_seen_at);
-    }
-
-    public function test_get_failed_jobs_retries_on_429_then_succeeds(): void
-    {
-        $calls = 0;
-        Http::fake(function () use (&$calls) {
-            $calls++;
-            if ($calls < 3) {
-                return Http::response(['message' => 'Rate limited'], 429);
-            }
-
-            return Http::response(['data' => ['jobs' => []]], 200);
-        });
-
-        \config()->set('horizonhub.horizon_http_retry', [
-            'times' => 3,
-            'sleep_ms' => 0,
-            'retry_on_status' => [429, 502, 503, 504],
-        ]);
-        \config()->set('horizonhub.horizon_paths.api', '/horizon/api');
-        \config()->set('horizonhub.horizon_paths.failed_jobs', '/jobs/failed');
-
-        $service = Service::create([
-            'name' => 'svc-retry-429',
-            'base_url' => 'https://service-retry-429.test',
-            'status' => 'online',
-        ]);
-
-        $proxy = new HorizonApiProxyService;
-        $result = $proxy->getFailedJobs($service, ['starting_at' => 0, 'limit' => 10]);
-
-        $this->assertTrue($result['success']);
-        $this->assertSame(3, $calls);
-        $this->assertArrayHasKey('data', $result);
     }
 }

--- a/tests/Unit/HorizonJobDetailServiceTest.php
+++ b/tests/Unit/HorizonJobDetailServiceTest.php
@@ -12,7 +12,7 @@ use Tests\TestCase;
 class HorizonJobDetailServiceTest extends TestCase
 {
     #[Test]
-    public function it_reads_queued_at_from_payload_for_completed_jobs(): void
+    public function it_computes_runtime_from_reserved_to_failed_when_runtime_is_missing(): void
     {
         $service = new Service;
         $service->forceFill([
@@ -21,29 +21,111 @@ class HorizonJobDetailServiceTest extends TestCase
         ]);
 
         $jobData = [
-            'uuid' => 'job-123',
-            'name' => 'App\\Jobs\\ProcessOrder',
+            'uuid' => 'job-failed-runtime-derived',
+            'name' => 'App\\Jobs\\FailingJob',
             'queue' => 'default',
-            'status' => 'completed',
-            'failed_at' => false,
-            'completed_at' => '2026-03-24T10:10:00+00:00',
+            'status' => 'failed',
+            'reserved_at' => '1711111111.100',
+            'failed_at' => '1711111111.140',
+        ];
+
+        $serviceUnderTest = new HorizonJobDetailService;
+        $result = $serviceUnderTest->buildShowViewData($service, $jobData, 'job-failed-runtime-derived');
+
+        $this->assertSame('0.04 s', $result['job']->runtime);
+    }
+
+    #[Test]
+    public function it_derives_available_at_from_serialized_command_when_payload_delay_is_null(): void
+    {
+        $service = new Service;
+        $service->forceFill([
+            'name' => 'Orders API',
+            'base_url' => 'http://example.test',
+        ]);
+
+        $job = new EvaluateAlertJob(9, 'eval-delay-payload');
+        $job->delay(300);
+
+        $jobData = [
+            'uuid' => 'job-serialized-delay',
+            'name' => EvaluateAlertJob::class,
+            'queue' => 'default',
+            'status' => 'pending',
             'payload' => [
-                'pushedAt' => '1711111111.123',
+                'pushedAt' => '1711111111.000',
+                'delay' => null,
+                'data' => [
+                    'commandName' => EvaluateAlertJob::class,
+                    'command' => serialize(clone $job),
+                ],
             ],
         ];
 
         $serviceUnderTest = new HorizonJobDetailService;
-        $result = $serviceUnderTest->buildShowViewData($service, $jobData, 'job-123');
+        $result = $serviceUnderTest->buildShowViewData($service, $jobData, 'job-serialized-delay');
 
-        $this->assertArrayHasKey('job', $result);
-        $this->assertSame('processed', $result['job']->status);
-        $this->assertInstanceOf(Carbon::class, $result['job']->queued_at);
-        $this->assertSame(
-            Carbon::createFromTimestampMs(1711111111123)->toIso8601String(),
-            $result['job']->queued_at->toIso8601String()
-        );
-        $this->assertInstanceOf(Carbon::class, $result['job']->processed_at);
-        $this->assertNull($result['job']->failed_at);
+        $this->assertNull($result['job']->available_at);
+    }
+
+    #[Test]
+    public function it_does_not_compute_failed_runtime_from_pushed_to_failed_when_reserved_at_is_missing(): void
+    {
+        $service = new Service;
+        $service->forceFill([
+            'name' => 'Orders API',
+            'base_url' => 'http://example.test',
+        ]);
+
+        $jobData = [
+            'uuid' => 'job-failed-runtime-missing',
+            'name' => 'App\\Jobs\\FailingJob',
+            'queue' => 'default',
+            'status' => 'failed',
+            'payload' => [
+                'pushedAt' => '1711111111.123',
+            ],
+            'failed_at' => '2026-03-24T10:10:00+00:00',
+        ];
+
+        $serviceUnderTest = new HorizonJobDetailService;
+        $result = $serviceUnderTest->buildShowViewData($service, $jobData, 'job-failed-runtime-missing');
+
+        $this->assertNull($result['job']->runtime);
+    }
+
+    #[Test]
+    public function it_exposes_delay_and_available_at_for_delayed_jobs(): void
+    {
+        $service = new Service;
+        $service->forceFill([
+            'name' => 'Orders API',
+            'base_url' => 'http://example.test',
+        ]);
+
+        $delayAt = Carbon::parse('2026-04-15 12:59:10');
+        $job = new EvaluateAlertJob(99, 'eval-delay-date');
+        $job->delay($delayAt);
+
+        $jobData = [
+            'uuid' => 'job-delayed',
+            'name' => EvaluateAlertJob::class,
+            'queue' => 'default',
+            'status' => 'pending',
+            'payload' => [
+                'pushedAt' => '1711111111.000',
+                'data' => [
+                    'commandName' => EvaluateAlertJob::class,
+                    'command' => serialize(clone $job),
+                ],
+            ],
+        ];
+
+        $serviceUnderTest = new HorizonJobDetailService;
+        $result = $serviceUnderTest->buildShowViewData($service, $jobData, 'job-delayed');
+
+        $this->assertInstanceOf(Carbon::class, $result['job']->available_at);
+        $this->assertSame($delayAt->toIso8601String(), $result['job']->available_at->toIso8601String());
     }
 
     #[Test]
@@ -148,7 +230,7 @@ class HorizonJobDetailServiceTest extends TestCase
     }
 
     #[Test]
-    public function it_exposes_delay_and_available_at_for_delayed_jobs(): void
+    public function it_reads_queued_at_from_payload_for_completed_jobs(): void
     {
         $service = new Service;
         $service->forceFill([
@@ -156,33 +238,34 @@ class HorizonJobDetailServiceTest extends TestCase
             'base_url' => 'http://example.test',
         ]);
 
-        $delayAt = Carbon::parse('2026-04-15 12:59:10');
-        $job = new EvaluateAlertJob(99, 'eval-delay-date');
-        $job->delay($delayAt);
-
         $jobData = [
-            'uuid' => 'job-delayed',
-            'name' => EvaluateAlertJob::class,
+            'uuid' => 'job-123',
+            'name' => 'App\\Jobs\\ProcessOrder',
             'queue' => 'default',
-            'status' => 'pending',
+            'status' => 'completed',
+            'failed_at' => false,
+            'completed_at' => '2026-03-24T10:10:00+00:00',
             'payload' => [
-                'pushedAt' => '1711111111.000',
-                'data' => [
-                    'commandName' => EvaluateAlertJob::class,
-                    'command' => serialize(clone $job),
-                ],
+                'pushedAt' => '1711111111.123',
             ],
         ];
 
         $serviceUnderTest = new HorizonJobDetailService;
-        $result = $serviceUnderTest->buildShowViewData($service, $jobData, 'job-delayed');
+        $result = $serviceUnderTest->buildShowViewData($service, $jobData, 'job-123');
 
-        $this->assertInstanceOf(Carbon::class, $result['job']->available_at);
-        $this->assertSame($delayAt->toIso8601String(), $result['job']->available_at->toIso8601String());
+        $this->assertArrayHasKey('job', $result);
+        $this->assertSame('processed', $result['job']->status);
+        $this->assertInstanceOf(Carbon::class, $result['job']->queued_at);
+        $this->assertSame(
+            Carbon::createFromTimestampMs(1711111111123)->toIso8601String(),
+            $result['job']->queued_at->toIso8601String()
+        );
+        $this->assertInstanceOf(Carbon::class, $result['job']->processed_at);
+        $this->assertNull($result['job']->failed_at);
     }
 
     #[Test]
-    public function it_derives_available_at_from_serialized_command_when_payload_delay_is_null(): void
+    public function it_sets_null_delay_when_no_delay_present(): void
     {
         $service = new Service;
         $service->forceFill([
@@ -190,26 +273,19 @@ class HorizonJobDetailServiceTest extends TestCase
             'base_url' => 'http://example.test',
         ]);
 
-        $job = new EvaluateAlertJob(9, 'eval-delay-payload');
-        $job->delay(300);
-
         $jobData = [
-            'uuid' => 'job-serialized-delay',
-            'name' => EvaluateAlertJob::class,
+            'uuid' => 'job-no-delay',
+            'name' => 'App\\Jobs\\ImmediateJob',
             'queue' => 'default',
-            'status' => 'pending',
+            'status' => 'completed',
+            'completed_at' => '2026-03-24T10:10:00+00:00',
             'payload' => [
                 'pushedAt' => '1711111111.000',
-                'delay' => null,
-                'data' => [
-                    'commandName' => EvaluateAlertJob::class,
-                    'command' => serialize(clone $job),
-                ],
             ],
         ];
 
         $serviceUnderTest = new HorizonJobDetailService;
-        $result = $serviceUnderTest->buildShowViewData($service, $jobData, 'job-serialized-delay');
+        $result = $serviceUnderTest->buildShowViewData($service, $jobData, 'job-no-delay');
 
         $this->assertNull($result['job']->available_at);
     }
@@ -247,81 +323,5 @@ class HorizonJobDetailServiceTest extends TestCase
 
         $this->assertInstanceOf(Carbon::class, $result['job']->available_at);
         $this->assertSame($delayAt->toIso8601String(), $result['job']->available_at->toIso8601String());
-    }
-
-    #[Test]
-    public function it_sets_null_delay_when_no_delay_present(): void
-    {
-        $service = new Service;
-        $service->forceFill([
-            'name' => 'Orders API',
-            'base_url' => 'http://example.test',
-        ]);
-
-        $jobData = [
-            'uuid' => 'job-no-delay',
-            'name' => 'App\\Jobs\\ImmediateJob',
-            'queue' => 'default',
-            'status' => 'completed',
-            'completed_at' => '2026-03-24T10:10:00+00:00',
-            'payload' => [
-                'pushedAt' => '1711111111.000',
-            ],
-        ];
-
-        $serviceUnderTest = new HorizonJobDetailService;
-        $result = $serviceUnderTest->buildShowViewData($service, $jobData, 'job-no-delay');
-
-        $this->assertNull($result['job']->available_at);
-    }
-
-    #[Test]
-    public function it_does_not_compute_failed_runtime_from_pushed_to_failed_when_reserved_at_is_missing(): void
-    {
-        $service = new Service;
-        $service->forceFill([
-            'name' => 'Orders API',
-            'base_url' => 'http://example.test',
-        ]);
-
-        $jobData = [
-            'uuid' => 'job-failed-runtime-missing',
-            'name' => 'App\\Jobs\\FailingJob',
-            'queue' => 'default',
-            'status' => 'failed',
-            'payload' => [
-                'pushedAt' => '1711111111.123',
-            ],
-            'failed_at' => '2026-03-24T10:10:00+00:00',
-        ];
-
-        $serviceUnderTest = new HorizonJobDetailService;
-        $result = $serviceUnderTest->buildShowViewData($service, $jobData, 'job-failed-runtime-missing');
-
-        $this->assertNull($result['job']->runtime);
-    }
-
-    #[Test]
-    public function it_computes_runtime_from_reserved_to_failed_when_runtime_is_missing(): void
-    {
-        $service = new Service;
-        $service->forceFill([
-            'name' => 'Orders API',
-            'base_url' => 'http://example.test',
-        ]);
-
-        $jobData = [
-            'uuid' => 'job-failed-runtime-derived',
-            'name' => 'App\\Jobs\\FailingJob',
-            'queue' => 'default',
-            'status' => 'failed',
-            'reserved_at' => '1711111111.100',
-            'failed_at' => '1711111111.140',
-        ];
-
-        $serviceUnderTest = new HorizonJobDetailService;
-        $result = $serviceUnderTest->buildShowViewData($service, $jobData, 'job-failed-runtime-derived');
-
-        $this->assertSame('0.04 s', $result['job']->runtime);
     }
 }

--- a/tests/Unit/HorizonJobListServiceRetryModalTest.php
+++ b/tests/Unit/HorizonJobListServiceRetryModalTest.php
@@ -13,47 +13,6 @@ class HorizonJobListServiceRetryModalTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_build_failed_jobs_retry_modal_page_with_max_per_page_returns_all_rows(): void
-    {
-        $api = $this->createMock(HorizonApiProxyService::class);
-        $api->method('getFailedJobs')
-            ->willReturn([
-                'success' => true,
-                'data' => [
-                    'jobs' => [
-                        [
-                            'id' => 'job-a',
-                            'queue' => 'default',
-                            'name' => 'JobA',
-                            'failed_at' => '2024-06-01 10:00:00',
-                        ],
-                        [
-                            'id' => 'job-b',
-                            'queue' => 'default',
-                            'name' => 'JobB',
-                            'failed_at' => '2024-06-01 11:00:00',
-                        ],
-                    ],
-                ],
-            ]);
-
-        $svc = Service::create([
-            'name' => 'svc-retry-modal-batch',
-            'base_url' => 'https://svc-retry-modal.test',
-            'status' => 'online',
-        ]);
-
-        $list = new HorizonJobListService($api);
-        $services = new Collection([$svc]);
-
-        $all = $list->buildFailedJobsRetryModalPage($services, '', null, null, 1, \PHP_INT_MAX);
-
-        $this->assertSame(2, $all['total']);
-        $this->assertCount(2, $all['rows']);
-        $this->assertSame('job-b', $all['rows'][0]['uuid']);
-        $this->assertSame('job-a', $all['rows'][1]['uuid']);
-    }
-
     public function test_build_failed_jobs_retry_modal_page_slice_matches_full_total(): void
     {
         $api = $this->createMock(HorizonApiProxyService::class);
@@ -100,5 +59,46 @@ class HorizonJobListServiceRetryModalTest extends TestCase
         $this->assertCount(1, $page['rows']);
         $this->assertSame('job-3', $page['rows'][0]['uuid']);
         $this->assertCount(3, $all['rows']);
+    }
+
+    public function test_build_failed_jobs_retry_modal_page_with_max_per_page_returns_all_rows(): void
+    {
+        $api = $this->createMock(HorizonApiProxyService::class);
+        $api->method('getFailedJobs')
+            ->willReturn([
+                'success' => true,
+                'data' => [
+                    'jobs' => [
+                        [
+                            'id' => 'job-a',
+                            'queue' => 'default',
+                            'name' => 'JobA',
+                            'failed_at' => '2024-06-01 10:00:00',
+                        ],
+                        [
+                            'id' => 'job-b',
+                            'queue' => 'default',
+                            'name' => 'JobB',
+                            'failed_at' => '2024-06-01 11:00:00',
+                        ],
+                    ],
+                ],
+            ]);
+
+        $svc = Service::create([
+            'name' => 'svc-retry-modal-batch',
+            'base_url' => 'https://svc-retry-modal.test',
+            'status' => 'online',
+        ]);
+
+        $list = new HorizonJobListService($api);
+        $services = new Collection([$svc]);
+
+        $all = $list->buildFailedJobsRetryModalPage($services, '', null, null, 1, \PHP_INT_MAX);
+
+        $this->assertSame(2, $all['total']);
+        $this->assertCount(2, $all['rows']);
+        $this->assertSame('job-b', $all['rows'][0]['uuid']);
+        $this->assertSame('job-a', $all['rows'][1]['uuid']);
     }
 }

--- a/tests/Unit/HorizonMetricsServiceTest.php
+++ b/tests/Unit/HorizonMetricsServiceTest.php
@@ -14,123 +14,60 @@ class HorizonMetricsServiceTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_queue_name_normalizer_strips_redis_prefix(): void
-    {
-        $this->assertNull(QueueNameNormalizer::normalize(null));
-        $this->assertSame('', QueueNameNormalizer::normalize(''));
-        $this->assertSame('default', QueueNameNormalizer::normalize('redis.default'));
-        $this->assertSame('default', QueueNameNormalizer::normalize('redis:default'));
-        $this->assertSame('emails', QueueNameNormalizer::normalize('database.emails'));
-        $this->assertSame('notifications', QueueNameNormalizer::normalize('sqs:notifications'));
-        $this->assertSame('redis.', QueueNameNormalizer::normalize('redis.'));
-        $this->assertSame('alpha', QueueNameNormalizer::normalize('alpha'));
-    }
-
-    public function test_queue_name_normalizer_strips_custom_connection_prefix_via_fallback_pattern(): void
-    {
-        $this->assertSame('jobs', QueueNameNormalizer::normalize('acme_worker:jobs'));
-        $this->assertSame('emails', QueueNameNormalizer::normalize('acme_worker.emails'));
-    }
-
-    public function test_queue_name_normalizer_prefers_longest_queue_config_connection_name(): void
-    {
-        \config(['queue.connections.redis_cluster' => ['driver' => 'redis']]);
-
-        $this->assertSame('default', QueueNameNormalizer::normalize('redis_cluster:default'));
-        $this->assertSame('default', QueueNameNormalizer::normalize('redis:default'));
-    }
-
-    public function test_queue_name_normalizer_does_not_strip_when_leading_segment_starts_with_digit(): void
-    {
-        $this->assertSame('1queue:jobs', QueueNameNormalizer::normalize('1queue:jobs'));
-    }
-
-    public function test_get_workload_for_service_maps_nested_data_payload(): void
+    public function test_get_failure_rate_24h_fetches_multiple_horizon_pages_using_index_cursor(): void
     {
         $api = $this->createMock(HorizonApiProxyService::class);
-        $api->expects($this->once())
-            ->method('getWorkload')
-            ->willReturn([
-                'success' => true,
-                'data' => [
-                    'data' => [
-                        ['name' => 'redis.default', 'length' => 7, 'processes' => 2, 'wait' => 1.5],
-                    ],
-                ],
-            ]);
+
+        $now = Carbon::parse('2026-03-20 15:30:00');
+        Carbon::setTestNow($now);
 
         $service = Service::create([
-            'name' => 'svc-a',
-            'base_url' => 'https://metrics.test',
+            'name' => 'svc-pagination',
+            'base_url' => 'https://metrics-pagination.test',
             'status' => 'online',
         ]);
 
-        $metrics = new HorizonMetricsService($api);
-        $rows = $metrics->getWorkloadForService($service);
+        $since = $now->copy()->subDay()->startOfDay();
+        $sinceTs = $since->getTimestamp();
+        $completedTs = $sinceTs + 3600;
 
-        $this->assertCount(1, $rows);
-        $this->assertSame('default', $rows[0]['queue']);
-        $this->assertSame(7, $rows[0]['jobs']);
-        $this->assertSame(2, $rows[0]['processes']);
-        $this->assertSame(1.5, $rows[0]['wait']);
-    }
+        $api->method('getCompletedJobs')->willReturnCallback(function ($svc, array $query) use ($service, $completedTs): array {
+            $this->assertInstanceOf(Service::class, $svc);
+            $this->assertSame((int) $service->id, (int) $svc->id);
+            $startingAt = (int) ($query['starting_at'] ?? -1);
+            if ($startingAt === -1) {
+                $jobs = [];
+                for ($i = 0; $i < 50; $i++) {
+                    $jobs[] = [
+                        'completed_at' => $completedTs + $i,
+                        'index' => $i,
+                    ];
+                }
 
-    public function test_get_workload_for_service_returns_empty_without_base_url(): void
-    {
-        $api = $this->createMock(HorizonApiProxyService::class);
-        $api->expects($this->never())->method('getWorkload');
+                return ['success' => true, 'data' => ['jobs' => $jobs]];
+            }
+            if ($startingAt === 49) {
+                return ['success' => true, 'data' => ['jobs' => [
+                    ['completed_at' => $completedTs + 100, 'index' => 50],
+                ]]];
+            }
 
-        $service = Service::create([
-            'name' => 'svc-b',
-            'base_url' => '',
-            'status' => 'online',
-        ]);
+            return ['success' => true, 'data' => ['jobs' => []]];
+        });
 
-        $metrics = new HorizonMetricsService($api);
-        $this->assertSame([], $metrics->getWorkloadForService($service));
-    }
-
-    public function test_get_workload_for_service_returns_empty_when_api_fails(): void
-    {
-        $api = $this->createMock(HorizonApiProxyService::class);
-        $api->method('getWorkload')->willReturn([
-            'success' => false,
-            'status' => 503,
-            'message' => 'unavailable',
-        ]);
-
-        $service = Service::create([
-            'name' => 'svc-c',
-            'base_url' => 'https://metrics-c.test',
-            'status' => 'online',
-        ]);
-
-        $metrics = new HorizonMetricsService($api);
-        $this->assertSame([], $metrics->getWorkloadForService($service));
-    }
-
-    public function test_get_workload_for_service_accepts_numeric_indexed_rows(): void
-    {
-        $api = $this->createMock(HorizonApiProxyService::class);
-        $api->method('getWorkload')->willReturn([
+        $api->method('getFailedJobs')->willReturn([
             'success' => true,
-            'data' => [
-                ['name' => 'alpha', 'size' => 4],
-            ],
-        ]);
-
-        $service = Service::create([
-            'name' => 'svc-d',
-            'base_url' => 'https://metrics-d.test',
-            'status' => 'online',
+            'data' => ['jobs' => []],
         ]);
 
         $metrics = new HorizonMetricsService($api);
-        $rows = $metrics->getWorkloadForService($service);
+        $result = $metrics->getFailureRate24h([(int) $service->id]);
 
-        $this->assertCount(1, $rows);
-        $this->assertSame('alpha', $rows[0]['queue']);
-        $this->assertSame(4, $rows[0]['jobs']);
+        $this->assertSame(51, $result['processed']);
+        $this->assertSame(0, $result['failed']);
+        $this->assertSame(0.0, $result['rate']);
+
+        Carbon::setTestNow();
     }
 
     public function test_get_failure_rate_over_time_builds_expected_buckets_and_rates(): void
@@ -204,111 +141,6 @@ class HorizonMetricsServiceTest extends TestCase
         Carbon::setTestNow();
     }
 
-    public function test_get_jobs_volume_last24h_counts_hourly_completed_and_failed(): void
-    {
-        $api = $this->createMock(HorizonApiProxyService::class);
-
-        $now = Carbon::parse('2026-03-21 15:30:00');
-        Carbon::setTestNow($now);
-
-        $service = Service::create([
-            'name' => 'svc-jobs-volume-24h',
-            'base_url' => 'https://jobs-volume-24h.test',
-            'status' => 'online',
-        ]);
-
-        $sinceBucketStart = $now->copy()->subHours(24)->startOfHour();
-        $activeHour = $sinceBucketStart->copy()->addHour();
-
-        $api->method('getCompletedJobs')->willReturn([
-            'success' => true,
-            'data' => [
-                'jobs' => [
-                    ['completed_at' => $activeHour->copy()->addMinutes(10)->getTimestamp()],
-                    ['completed_at' => $activeHour->copy()->addMinutes(20)->getTimestamp()],
-                ],
-            ],
-        ]);
-        $api->method('getFailedJobs')->willReturn([
-            'success' => true,
-            'data' => [
-                'jobs' => [
-                    ['failed_at' => $activeHour->copy()->addMinutes(30)->getTimestamp()],
-                ],
-            ],
-        ]);
-
-        $metrics = new HorizonMetricsService($api);
-        $result = $metrics->getJobsVolumeLast24h([(int) $service->id]);
-
-        $this->assertCount(25, $result['xAxis']);
-        $this->assertCount(25, $result['completed']);
-        $this->assertCount(25, $result['failed']);
-
-        $this->assertSame(0, $result['completed'][0]);
-        $this->assertSame(0, $result['failed'][0]);
-        $this->assertSame(2, $result['completed'][1]);
-        $this->assertSame(1, $result['failed'][1]);
-
-        Carbon::setTestNow();
-    }
-
-    public function test_get_failure_rate_24h_fetches_multiple_horizon_pages_using_index_cursor(): void
-    {
-        $api = $this->createMock(HorizonApiProxyService::class);
-
-        $now = Carbon::parse('2026-03-20 15:30:00');
-        Carbon::setTestNow($now);
-
-        $service = Service::create([
-            'name' => 'svc-pagination',
-            'base_url' => 'https://metrics-pagination.test',
-            'status' => 'online',
-        ]);
-
-        $since = $now->copy()->subDay()->startOfDay();
-        $sinceTs = $since->getTimestamp();
-        $completedTs = $sinceTs + 3600;
-
-        $api->method('getCompletedJobs')->willReturnCallback(function ($svc, array $query) use ($service, $completedTs): array {
-            $this->assertInstanceOf(Service::class, $svc);
-            $this->assertSame((int) $service->id, (int) $svc->id);
-            $startingAt = (int) ($query['starting_at'] ?? -1);
-            if ($startingAt === -1) {
-                $jobs = [];
-                for ($i = 0; $i < 50; $i++) {
-                    $jobs[] = [
-                        'completed_at' => $completedTs + $i,
-                        'index' => $i,
-                    ];
-                }
-
-                return ['success' => true, 'data' => ['jobs' => $jobs]];
-            }
-            if ($startingAt === 49) {
-                return ['success' => true, 'data' => ['jobs' => [
-                    ['completed_at' => $completedTs + 100, 'index' => 50],
-                ]]];
-            }
-
-            return ['success' => true, 'data' => ['jobs' => []]];
-        });
-
-        $api->method('getFailedJobs')->willReturn([
-            'success' => true,
-            'data' => ['jobs' => []],
-        ]);
-
-        $metrics = new HorizonMetricsService($api);
-        $result = $metrics->getFailureRate24h([(int) $service->id]);
-
-        $this->assertSame(51, $result['processed']);
-        $this->assertSame(0, $result['failed']);
-        $this->assertSame(0.0, $result['rate']);
-
-        Carbon::setTestNow();
-    }
-
     public function test_get_job_runtimes_last24h_returns_sorted_points_with_seconds(): void
     {
         $api = $this->createMock(HorizonApiProxyService::class);
@@ -378,6 +210,55 @@ class HorizonMetricsServiceTest extends TestCase
         $this->assertSame($endNewer * 1000, $result['points'][2]['endAtMs']);
         $this->assertSame(120.0, $result['points'][2]['seconds']);
         $this->assertSame('completed', $result['points'][2]['status']);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_get_jobs_volume_last24h_counts_hourly_completed_and_failed(): void
+    {
+        $api = $this->createMock(HorizonApiProxyService::class);
+
+        $now = Carbon::parse('2026-03-21 15:30:00');
+        Carbon::setTestNow($now);
+
+        $service = Service::create([
+            'name' => 'svc-jobs-volume-24h',
+            'base_url' => 'https://jobs-volume-24h.test',
+            'status' => 'online',
+        ]);
+
+        $sinceBucketStart = $now->copy()->subHours(24)->startOfHour();
+        $activeHour = $sinceBucketStart->copy()->addHour();
+
+        $api->method('getCompletedJobs')->willReturn([
+            'success' => true,
+            'data' => [
+                'jobs' => [
+                    ['completed_at' => $activeHour->copy()->addMinutes(10)->getTimestamp()],
+                    ['completed_at' => $activeHour->copy()->addMinutes(20)->getTimestamp()],
+                ],
+            ],
+        ]);
+        $api->method('getFailedJobs')->willReturn([
+            'success' => true,
+            'data' => [
+                'jobs' => [
+                    ['failed_at' => $activeHour->copy()->addMinutes(30)->getTimestamp()],
+                ],
+            ],
+        ]);
+
+        $metrics = new HorizonMetricsService($api);
+        $result = $metrics->getJobsVolumeLast24h([(int) $service->id]);
+
+        $this->assertCount(25, $result['xAxis']);
+        $this->assertCount(25, $result['completed']);
+        $this->assertCount(25, $result['failed']);
+
+        $this->assertSame(0, $result['completed'][0]);
+        $this->assertSame(0, $result['failed'][0]);
+        $this->assertSame(2, $result['completed'][1]);
+        $this->assertSame(1, $result['failed'][1]);
 
         Carbon::setTestNow();
     }
@@ -477,5 +358,124 @@ class HorizonMetricsServiceTest extends TestCase
             ['queue' => 'a'],
             ['queue' => 'b', 'wait' => null],
         ]));
+    }
+
+    public function test_get_workload_for_service_accepts_numeric_indexed_rows(): void
+    {
+        $api = $this->createMock(HorizonApiProxyService::class);
+        $api->method('getWorkload')->willReturn([
+            'success' => true,
+            'data' => [
+                ['name' => 'alpha', 'size' => 4],
+            ],
+        ]);
+
+        $service = Service::create([
+            'name' => 'svc-d',
+            'base_url' => 'https://metrics-d.test',
+            'status' => 'online',
+        ]);
+
+        $metrics = new HorizonMetricsService($api);
+        $rows = $metrics->getWorkloadForService($service);
+
+        $this->assertCount(1, $rows);
+        $this->assertSame('alpha', $rows[0]['queue']);
+        $this->assertSame(4, $rows[0]['jobs']);
+    }
+
+    public function test_get_workload_for_service_maps_nested_data_payload(): void
+    {
+        $api = $this->createMock(HorizonApiProxyService::class);
+        $api->expects($this->once())
+            ->method('getWorkload')
+            ->willReturn([
+                'success' => true,
+                'data' => [
+                    'data' => [
+                        ['name' => 'redis.default', 'length' => 7, 'processes' => 2, 'wait' => 1.5],
+                    ],
+                ],
+            ]);
+
+        $service = Service::create([
+            'name' => 'svc-a',
+            'base_url' => 'https://metrics.test',
+            'status' => 'online',
+        ]);
+
+        $metrics = new HorizonMetricsService($api);
+        $rows = $metrics->getWorkloadForService($service);
+
+        $this->assertCount(1, $rows);
+        $this->assertSame('default', $rows[0]['queue']);
+        $this->assertSame(7, $rows[0]['jobs']);
+        $this->assertSame(2, $rows[0]['processes']);
+        $this->assertSame(1.5, $rows[0]['wait']);
+    }
+
+    public function test_get_workload_for_service_returns_empty_when_api_fails(): void
+    {
+        $api = $this->createMock(HorizonApiProxyService::class);
+        $api->method('getWorkload')->willReturn([
+            'success' => false,
+            'status' => 503,
+            'message' => 'unavailable',
+        ]);
+
+        $service = Service::create([
+            'name' => 'svc-c',
+            'base_url' => 'https://metrics-c.test',
+            'status' => 'online',
+        ]);
+
+        $metrics = new HorizonMetricsService($api);
+        $this->assertSame([], $metrics->getWorkloadForService($service));
+    }
+
+    public function test_get_workload_for_service_returns_empty_without_base_url(): void
+    {
+        $api = $this->createMock(HorizonApiProxyService::class);
+        $api->expects($this->never())->method('getWorkload');
+
+        $service = Service::create([
+            'name' => 'svc-b',
+            'base_url' => '',
+            'status' => 'online',
+        ]);
+
+        $metrics = new HorizonMetricsService($api);
+        $this->assertSame([], $metrics->getWorkloadForService($service));
+    }
+
+    public function test_queue_name_normalizer_does_not_strip_when_leading_segment_starts_with_digit(): void
+    {
+        $this->assertSame('1queue:jobs', QueueNameNormalizer::normalize('1queue:jobs'));
+    }
+
+    public function test_queue_name_normalizer_prefers_longest_queue_config_connection_name(): void
+    {
+        \config(['queue.connections.redis_cluster' => ['driver' => 'redis']]);
+
+        $this->assertSame('default', QueueNameNormalizer::normalize('redis_cluster:default'));
+        $this->assertSame('default', QueueNameNormalizer::normalize('redis:default'));
+    }
+
+    public function test_queue_name_normalizer_strips_custom_connection_prefix_via_fallback_pattern(): void
+    {
+        $this->assertSame('jobs', QueueNameNormalizer::normalize('acme_worker:jobs'));
+        $this->assertSame('emails', QueueNameNormalizer::normalize('acme_worker.emails'));
+    }
+
+    public function test_queue_name_normalizer_strips_redis_prefix(): void
+    {
+        $this->assertNull(QueueNameNormalizer::normalize(null));
+        $this->assertSame('', QueueNameNormalizer::normalize(''));
+        $this->assertSame('default', QueueNameNormalizer::normalize('redis.default'));
+        $this->assertSame('default', QueueNameNormalizer::normalize('redis:default'));
+        $this->assertSame('emails', QueueNameNormalizer::normalize('database.emails'));
+        $this->assertSame('notifications', QueueNameNormalizer::normalize('sqs:notifications'));
+        $this->assertSame('redis.', QueueNameNormalizer::normalize('redis.'));
+        $this->assertSame('alpha', QueueNameNormalizer::normalize('alpha'));
     }
 }

--- a/tests/Unit/JobDashboardUrlBuilderTest.php
+++ b/tests/Unit/JobDashboardUrlBuilderTest.php
@@ -24,20 +24,6 @@ class JobDashboardUrlBuilderTest extends TestCase
     }
 
     #[Test]
-    public function it_uses_public_url_when_available(): void
-    {
-        $service = new Service;
-        $service->forceFill([
-            'base_url' => 'http://internal.test',
-            'public_url' => 'http://public.test',
-        ]);
-
-        $url = JobDashboardUrlBuilder::build($service, 'abc-123', 'failed');
-
-        $this->assertSame('http://public.test/horizon/failed/abc-123', $url);
-    }
-
-    #[Test]
     public function it_returns_null_when_required_values_are_missing(): void
     {
         $service = new Service;
@@ -49,5 +35,19 @@ class JobDashboardUrlBuilderTest extends TestCase
         $this->assertNull(JobDashboardUrlBuilder::build($service, 'abc-123', 'processed'));
         $this->assertNull(JobDashboardUrlBuilder::build(null, 'abc-123', 'processed'));
         $this->assertNull(JobDashboardUrlBuilder::build($service, '', 'processed'));
+    }
+
+    #[Test]
+    public function it_uses_public_url_when_available(): void
+    {
+        $service = new Service;
+        $service->forceFill([
+            'base_url' => 'http://internal.test',
+            'public_url' => 'http://public.test',
+        ]);
+
+        $url = JobDashboardUrlBuilder::build($service, 'abc-123', 'failed');
+
+        $this->assertSame('http://public.test/horizon/failed/abc-123', $url);
     }
 }

--- a/tests/Unit/RetryModalDateFilterRuleTest.php
+++ b/tests/Unit/RetryModalDateFilterRuleTest.php
@@ -9,19 +9,16 @@ use Tests\TestCase;
 class RetryModalDateFilterRuleTest extends TestCase
 {
     #[Test]
-    public function passes_for_date_only_and_datetime_strings(): void
+    public function allows_null_and_empty(): void
     {
         $rule = new RetryModalDateFilter;
-        $failed = false;
-        $rule->validate('date_from', '2026-03-21', function () use (&$failed): void {
-            $failed = true;
-        });
-        $this->assertFalse($failed);
-
-        $rule->validate('date_from', '2026-03-21T15:03', function () use (&$failed): void {
-            $failed = true;
-        });
-        $this->assertFalse($failed);
+        foreach ([null, '', '   '] as $value) {
+            $failed = false;
+            $rule->validate('date_from', $value, function () use (&$failed): void {
+                $failed = true;
+            });
+            $this->assertFalse($failed, 'Expected pass for value: '.\var_export($value, true));
+        }
     }
 
     #[Test]
@@ -36,15 +33,18 @@ class RetryModalDateFilterRuleTest extends TestCase
     }
 
     #[Test]
-    public function allows_null_and_empty(): void
+    public function passes_for_date_only_and_datetime_strings(): void
     {
         $rule = new RetryModalDateFilter;
-        foreach ([null, '', '   '] as $value) {
-            $failed = false;
-            $rule->validate('date_from', $value, function () use (&$failed): void {
-                $failed = true;
-            });
-            $this->assertFalse($failed, 'Expected pass for value: '.\var_export($value, true));
-        }
+        $failed = false;
+        $rule->validate('date_from', '2026-03-21', function () use (&$failed): void {
+            $failed = true;
+        });
+        $this->assertFalse($failed);
+
+        $rule->validate('date_from', '2026-03-21T15:03', function () use (&$failed): void {
+            $failed = true;
+        });
+        $this->assertFalse($failed);
     }
 }

--- a/tests/Unit/ServiceRequestServiceIdsTest.php
+++ b/tests/Unit/ServiceRequestServiceIdsTest.php
@@ -12,15 +12,6 @@ class ServiceRequestServiceIdsTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_parse_positive_int_ids_from_array_and_scalar(): void
-    {
-        $this->assertSame([1, 2], ServiceRequest::parseIds(['1', '2', '1']));
-        $this->assertSame([5], ServiceRequest::parseIds('5'));
-        $this->assertSame([], ServiceRequest::parseIds([]));
-        $this->assertSame([], ServiceRequest::parseIds('x'));
-        $this->assertSame([], ServiceRequest::parseIds(null));
-    }
-
     public function test_existing_ids_from_request_uses_first_non_empty_key(): void
     {
         $s1 = Service::create([
@@ -42,5 +33,14 @@ class ServiceRequestServiceIdsTest extends TestCase
         $request2 = Request::create('/x?second%5B%5D='.$s1->id, 'GET');
         $ids2 = ServiceRequest::existingIdsFromRequest($request2, ['first', 'second']);
         $this->assertSame([(int) $s1->id], $ids2);
+    }
+
+    public function test_parse_positive_int_ids_from_array_and_scalar(): void
+    {
+        $this->assertSame([1, 2], ServiceRequest::parseIds(['1', '2', '1']));
+        $this->assertSame([5], ServiceRequest::parseIds('5'));
+        $this->assertSame([], ServiceRequest::parseIds([]));
+        $this->assertSame([], ServiceRequest::parseIds('x'));
+        $this->assertSame([], ServiceRequest::parseIds(null));
     }
 }


### PR DESCRIPTION
- Introduced new rules for method ordering in classes, specifying visibility and alphabetical order.
- Added a requirement for private methods to use a `private__` prefix across PHP, JavaScript, and TypeScript.
- Updated relevant files to implement these new rules, ensuring consistency in method organization and naming conventions.