### PR TITLE
Enhance Horizon API error handling and configuration, avoiding excesive HTTP timeouts that generates 504 error codes from navigator. And some other fixes and cleanups for redundant staff.

### DIFF
--- a/app/Http/Controllers/StreamController.php
+++ b/app/Http/Controllers/StreamController.php
@@ -16,9 +16,10 @@ abstract class StreamController extends Controller
      */
     protected function runStream(callable $turboStreamCallback): StreamedResponse
     {
-        $interval = (int) config('horizonhub.hot_reload_interval');
+        $intervalSeconds = (float) config('horizonhub.hot_reload_interval');
+        $intervalMicroseconds = (int) ($intervalSeconds * 1_000_000);
 
-        return \response()->stream(function () use ($interval, $turboStreamCallback): void {
+        return \response()->stream(function () use ($intervalMicroseconds, $turboStreamCallback): void {
             echo ": stream-open\n\n";
             if (\function_exists('ob_flush')) {
                 @\ob_flush();
@@ -53,7 +54,7 @@ abstract class StreamController extends Controller
                     break;
                 }
 
-                \usleep($interval);
+                \usleep($intervalMicroseconds);
             }
         }, 200, $this->streamHeaders());
     }

--- a/app/Services/Horizon/HorizonApiProxyService.php
+++ b/app/Services/Horizon/HorizonApiProxyService.php
@@ -4,10 +4,12 @@ namespace App\Services\Horizon;
 
 use App\Models\Service;
 use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
@@ -109,7 +111,7 @@ class HorizonApiProxyService
         $relativePath = (string) config('horizonhub.horizon_paths.workload');
 
         $result = $this->private__call($service, $relativePath, 'get');
-        if (! ($result['success'] ?? false) && \in_array($result['status'] ?? 0, [401, 403], true)) {
+        if (! ($result['success'] ?? false) && \in_array((int) ($result['status'] ?? 0), config('horizonhub.horizon_http_auth_statuses'), true)) {
             $result = $this->private__call($service, $relativePath, 'get', true);
         }
 
@@ -155,17 +157,7 @@ class HorizonApiProxyService
      */
     private function private__bootstrapDashboardSession(Service $service): ?array
     {
-        $serviceBase = $service->getBaseUrl();
-        if ($serviceBase === '') {
-            Log::warning('Horizon Hub: failed to build Horizon dashboard URL', [
-                'service_id' => $service->id ?? null,
-                'error' => 'missing base_url',
-            ]);
-
-            return null;
-        }
-
-        $dashboardUrl = $serviceBase.(string) config('horizonhub.horizon_paths.dashboard');
+        $dashboardUrl = $service->getBaseUrl().(string) config('horizonhub.horizon_paths.dashboard');
 
         $cookieJar = new CookieJar;
 
@@ -266,16 +258,15 @@ class HorizonApiProxyService
      */
     private function private__call(Service $service, string $path, string $method = 'post', bool $withDashboardSession = false): array
     {
-        $serviceBase = $service->getBaseUrl();
-        if ($serviceBase === '') {
+        if (Cache::has($this->private__failureCooldownCacheKey($service))) {
             return [
                 'success' => false,
-                'message' => 'Service has no base_url configured.',
-                'status' => 400,
+                'message' => 'Service temporarily in cooldown after recent upstream failures.',
+                'status' => 503,
             ];
         }
 
-        $base = $serviceBase.(string) config('horizonhub.horizon_paths.api');
+        $base = $service->getBaseUrl().(string) config('horizonhub.horizon_paths.api');
 
         $url = "$base/".\ltrim($path, '/');
 
@@ -316,26 +307,59 @@ class HorizonApiProxyService
                 }
             }
 
-            return $this->private__processHttpResponse(
+            $result = $this->private__processHttpResponse(
                 $response,
                 $service,
                 $url,
                 ! $withDashboardSession,
                 $withDashboardSession ? ' (with dashboard session)' : '',
             );
+            if ($result['success'] === true) {
+                Cache::forget($this->private__failureCooldownCacheKey($service));
+
+                return $result;
+            }
+
+            if (! \in_array($result['status'], config('horizonhub.horizon_http_auth_statuses'))) {
+                $this->private__putFailureCooldown($service);
+            }
+
+            return $result;
         } catch (\Throwable $e) {
             Log::error('Horizon Hub: Horizon API call exception'.($withDashboardSession ? ' (with dashboard session)' : ''), [
                 'service_id' => $service->id ?? null,
                 'url' => $url ?? null,
                 'error' => $e->getMessage(),
+                'exception' => $e::class,
             ]);
+            $this->private__putFailureCooldown($service);
+
+            $statusCode = $e->getCode();
+            // Default exceptions have status code 0, we want to separate network errors from other exceptions and return the appropiate status code
+            if ($statusCode === 0) {
+                $statusCode = $e instanceof ConnectionException
+                    || $e instanceof RequestException
+                    || $e instanceof GuzzleException
+                    ? 502
+                    : 500;
+            }
 
             return [
                 'success' => false,
                 'message' => $e->getMessage(),
-                'status' => 502,
+                'status' => $statusCode,
             ];
         }
+    }
+
+    /**
+     * Get the cache key for the failure cooldown.
+     *
+     * @param  Service  $service  The service.
+     */
+    private function private__failureCooldownCacheKey(Service $service): string
+    {
+        return "horizonhub:horizon-api-failure-cooldown:{$service->id}";
     }
 
     /**
@@ -426,5 +450,18 @@ class HorizonApiProxyService
             'message' => $message,
             'status' => $response->status(),
         ];
+    }
+
+    /**
+     * Store failure cooldown when Horizon API calls fail.
+     *
+     * @param  Service  $service  The service.
+     */
+    private function private__putFailureCooldown(Service $service): void
+    {
+        $seconds = (int) config('horizonhub.horizon_http_failure_cooldown_seconds');
+        if ($seconds > 0) {
+            Cache::put($this->private__failureCooldownCacheKey($service), true, \now()->addSeconds($seconds));
+        }
     }
 }

--- a/config/horizonhub.php
+++ b/config/horizonhub.php
@@ -102,7 +102,7 @@ return [
     | currently unreachable or timing out.
     |
     */
-    'horizon_http_failure_cooldown_seconds' => (int) env('HORIZON_HUB_HTTP_FAILURE_COOLDOWN_SECONDS', 20),
+    'horizon_http_failure_cooldown_seconds' => (int) env('HORIZON_HUB_HTTP_FAILURE_COOLDOWN_SECONDS', 60),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/horizonhub.php
+++ b/config/horizonhub.php
@@ -72,7 +72,7 @@ return [
     | POST/DELETE (e.g. job retry) are not retried here; session flow still handles 419.
     |
     | times: total attempts (1 = no retry). sleep_ms: base backoff in milliseconds (exponential).
-    | retry_on_status: HTTP statuses to retry after a response is received.
+    | retry_on_status: HTTP status codes to retry after a response is received.
     |
     */
     'horizon_http_retry' => [
@@ -80,6 +80,29 @@ return [
         'sleep_ms' => (int) env('HORIZON_HUB_HTTP_RETRY_SLEEP_MS', 100),
         'retry_on_status' => [429, 502, 503, 504],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Horizon HTTP auth/session code statuses
+    |--------------------------------------------------------------------------
+    |
+    | HTTP status codes that represent missing auth/session/CSRF context.
+    | These statuses can trigger a dashboard-session retry flow and are
+    | excluded from failure cooldown in order to prevent performing the mentioned flow.
+    |
+    */
+    'horizon_http_auth_statuses' => [401, 403, 419],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Horizon HTTP failure cooldown
+    |--------------------------------------------------------------------------
+    |
+    | Temporary cooldown for HTTP calls to services that are
+    | currently unreachable or timing out.
+    |
+    */
+    'horizon_http_failure_cooldown_seconds' => (int) env('HORIZON_HUB_HTTP_FAILURE_COOLDOWN_SECONDS', 20),
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/Unit/AgentProxyServiceTest.php
+++ b/tests/Unit/AgentProxyServiceTest.php
@@ -41,26 +41,6 @@ class AgentProxyServiceTest extends TestCase
         $this->assertSame('Rate limited', $result['message'] ?? null);
     }
 
-    public function test_ping_returns_error_when_service_has_no_base_url(): void
-    {
-        Http::fake();
-
-        $service = Service::create([
-            'name' => 'no-base',
-            'base_url' => '',
-            'status' => 'online',
-        ]);
-
-        \config()->set('horizonhub.horizon_paths.ping', '/stats');
-
-        $proxy = new HorizonApiProxyService;
-        $result = $proxy->ping($service);
-
-        $this->assertFalse($result['success']);
-        $this->assertSame(400, $result['status'] ?? null);
-        $this->assertStringContainsString('base_url', (string) ($result['message'] ?? ''));
-    }
-
     public function test_retry_job_calls_horizon_api_and_returns_success(): void
     {
         $capturedRetryRequest = null;

--- a/tests/Unit/HorizonApiProxyServiceTest.php
+++ b/tests/Unit/HorizonApiProxyServiceTest.php
@@ -5,6 +5,8 @@ namespace Tests\Unit;
 use App\Models\Service;
 use App\Services\Horizon\HorizonApiProxyService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
@@ -101,6 +103,7 @@ class HorizonApiProxyServiceTest extends TestCase
         \config()->set('horizonhub.horizon_paths.api', '/horizon/api');
         \config()->set('horizonhub.horizon_paths.workload', '/workload');
         \config()->set('horizonhub.horizon_paths.dashboard', '/horizon');
+        \config()->set('horizonhub.horizon_http_auth_statuses', [401, 403, 419]);
 
         $service = Service::create([
             'name' => 'svc-workload-fallback',
@@ -120,7 +123,7 @@ class HorizonApiProxyServiceTest extends TestCase
     public function test_ping_returns_502_on_http_exception(): void
     {
         Http::fake(function () {
-            throw new \RuntimeException('network down');
+            throw new ConnectionException('network down');
         });
 
         \config()->set('horizonhub.horizon_paths.api', '/horizon/api');
@@ -163,6 +166,45 @@ class HorizonApiProxyServiceTest extends TestCase
         $this->assertTrue($result['success']);
         $this->assertSame('online', $freshService->status);
         $this->assertNotNull($freshService->last_seen_at);
+    }
+
+    public function test_get_call_enters_failure_cooldown_and_skips_immediate_retry(): void
+    {
+        $calls = 0;
+        Http::fake(function () use (&$calls) {
+            $calls++;
+
+            return Http::response('Gateway Timeout', 504);
+        });
+
+        \config()->set('horizonhub.horizon_paths.api', '/horizon/api');
+        \config()->set('horizonhub.horizon_paths.ping', '/stats');
+        \config()->set('horizonhub.horizon_http_failure_cooldown_seconds', 60);
+        \config()->set('horizonhub.horizon_http_auth_statuses', [401, 403, 419]);
+        \config()->set('horizonhub.horizon_http_retry', [
+            'times' => 1,
+            'sleep_ms' => 0,
+            'retry_on_status' => [429, 502, 503, 504],
+        ]);
+
+        $service = Service::create([
+            'name' => 'svc-cooldown',
+            'base_url' => 'https://service-cooldown.test',
+            'status' => 'online',
+        ]);
+
+        Cache::forget('horizonhub:horizon-api-failure-cooldown:'.$service->id);
+
+        $proxy = new HorizonApiProxyService;
+
+        $first = $proxy->ping($service);
+        $second = $proxy->ping($service);
+
+        $this->assertFalse($first['success']);
+        $this->assertSame(504, $first['status'] ?? null);
+        $this->assertFalse($second['success']);
+        $this->assertSame(503, $second['status'] ?? null);
+        $this->assertSame(1, $calls);
     }
 
     public function test_retry_job_retries_once_after_419_response(): void


### PR DESCRIPTION
- Updated `HorizonApiProxyService` to implement a failure cooldown mechanism for HTTP calls, preventing immediate retries after failures.
- Introduced new configuration options for HTTP auth/session status codes and failure cooldown duration.
- Refactored the `runStream` method in `StreamController` to fix interval handling with microseconds.
- Removed redundant checks for base URL in tests and streamlined dashboard URL construction.
- Added tests to verify the new failure cooldown behavior and ensure proper handling of HTTP exceptions.