### PR TITLE
Enhance ServiceController to reset service failure cooldown

### DIFF
--- a/app/Http/Controllers/Horizon/ServiceController.php
+++ b/app/Http/Controllers/Horizon/ServiceController.php
@@ -125,7 +125,7 @@ class ServiceController extends Controller
     /**
      * Update an existing service.
      */
-    public function update(Request $request, Service $service): RedirectResponse
+    public function update(Request $request, Service $service, HorizonApiProxyService $horizonApi): RedirectResponse
     {
         $validated = $request->validate([
             'name' => 'required|string|max:255|unique:services,name,' . (int) $service->id,
@@ -138,6 +138,7 @@ class ServiceController extends Controller
             'base_url' => \rtrim($validated['base_url'], '/'),
             'public_url' => ! empty($validated['public_url']) ? \rtrim($validated['public_url'], '/') : null,
         ]);
+        $horizonApi->resetFailureCooldown($service);
 
         return redirect()
             ->route('horizon.services.index')

--- a/app/Services/Horizon/HorizonApiProxyService.php
+++ b/app/Services/Horizon/HorizonApiProxyService.php
@@ -141,6 +141,16 @@ class HorizonApiProxyService
     }
 
     /**
+     * Reset the failure cooldown for a service.
+     *
+     * @param Service $service The service.
+     */
+    public function resetFailureCooldown(Service $service): void
+    {
+        Cache::forget($this->private__failureCooldownCacheKey($service));
+    }
+
+    /**
      * Retry a job through the Horizon HTTP API.
      *
      * @param Service $service The service.

--- a/tests/Feature/ServiceControllerTest.php
+++ b/tests/Feature/ServiceControllerTest.php
@@ -52,6 +52,11 @@ class ServiceControllerTest extends TestCase
             ['success' => true],
             ['success' => false, 'message' => 'failed ping'],
         );
+        $api->expects($this->once())
+            ->method('resetFailureCooldown')
+            ->with($this->callback(function (Service $cooldownService) use ($service): bool {
+                return $cooldownService->id === $service->id;
+            }));
         $this->app->instance(HorizonApiProxyService::class, $api);
 
         $this->get(route('horizon.services.index'))->assertOk();


### PR DESCRIPTION
- Updated the update method in ServiceController to include HorizonApiProxyService for resetting the failure cooldown of a service upon update.
- Added resetFailureCooldown method in HorizonApiProxyService to clear the failure cooldown cache for a specified service.
- Updated ServiceControllerTest to verify the resetFailureCooldown method is called during service updates.