### PR TITLE
Refactor console command signatures for consistency

### DIFF
--- a/app/Console/Commands/EvaluateAlertsCommand.php
+++ b/app/Console/Commands/EvaluateAlertsCommand.php
@@ -7,7 +7,7 @@ use Illuminate\Console\Command;
 
 class EvaluateAlertsCommand extends Command
 {
-    protected $signature = 'horizonhub:evaluate-alerts';
+    protected $signature = 'hh:evaluate-alerts';
 
     protected $description = 'Evaluate Horizon Hub alert rules (worker offline, queue blocked, etc.)';
 

--- a/app/Console/Commands/MarkStaleServicesOfflineCommand.php
+++ b/app/Console/Commands/MarkStaleServicesOfflineCommand.php
@@ -7,7 +7,7 @@ use Illuminate\Console\Command;
 
 class MarkStaleServicesOfflineCommand extends Command
 {
-    protected $signature = 'horizonhub:mark-stale-services-offline';
+    protected $signature = 'hh:mark-stale-services-offline';
 
     protected $description = 'Mark services stand-by/offline and remove dead supervisors by last_seen_at thresholds';
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,5 +2,5 @@
 
 use Illuminate\Support\Facades\Schedule;
 
-Schedule::command('horizonhub:evaluate-alerts')->everyMinute();
-Schedule::command('horizonhub:mark-stale-services-offline')->everyMinute();
+Schedule::command('hh:evaluate-alerts')->everyMinute();
+Schedule::command('hh:mark-stale-services-offline')->everyMinute();

--- a/tests/Feature/ConsoleCommandsTest.php
+++ b/tests/Feature/ConsoleCommandsTest.php
@@ -17,7 +17,7 @@ class ConsoleCommandsTest extends TestCase
         $engine->expects($this->once())->method('evaluateScheduled');
         $this->app->instance(AlertEngine::class, $engine);
 
-        $this->artisan('horizonhub:evaluate-alerts')->assertSuccessful();
+        $this->artisan('hh:evaluate-alerts')->assertSuccessful();
     }
 
     public function test_mark_stale_services_offline_command_updates_status_by_thresholds(): void
@@ -38,7 +38,7 @@ class ConsoleCommandsTest extends TestCase
             'last_seen_at' => now()->subMinutes(70),
         ]);
 
-        $this->artisan('horizonhub:mark-stale-services-offline')->assertSuccessful();
+        $this->artisan('hh:mark-stale-services-offline')->assertSuccessful();
 
         $standBy->refresh();
         $offline->refresh();


### PR DESCRIPTION
- Updated command signatures from 'horizonhub:*' to 'hh:*' for EvaluateAlertsCommand and MarkStaleServicesOfflineCommand.
- Adjusted corresponding schedule commands in console routes.
- Modified tests to reflect the new command signatures.