### PR TITLE
Add custom exception handling for NotFoundHttpException

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,8 +3,10 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Support\Facades\Route;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -22,5 +24,11 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
-        //
+        $exceptions->render(function (NotFoundHttpException $exception, Request $request) {
+            if ($request->expectsJson()) {
+                return null;
+            }
+
+            return redirect()->route('horizon.index');
+        });
     })->create();

--- a/tests/Feature/NotFoundRedirectsToDashboardTest.php
+++ b/tests/Feature/NotFoundRedirectsToDashboardTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class NotFoundRedirectsToDashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_unknown_json_request_stays_not_found(): void
+    {
+        $response = $this->getJson('/path-that-does-not-exist-json');
+
+        $response->assertNotFound();
+    }
+
+    public function test_unknown_web_path_redirects_to_dashboard(): void
+    {
+        $response = $this->get('/path-that-does-not-exist-xyz');
+
+        $response->assertRedirect(route('horizon.index'));
+    }
+}


### PR DESCRIPTION
- Implemented a redirect to the Horizon dashboard for web requests that encounter a NotFoundHttpException, while preserving the 404 response for JSON requests.
- Added a new test case to verify the redirect behavior for unknown web paths and ensure JSON requests remain unaffected.