### PR TITLE
Refactor resizable table and enhance job selection in Horizon

### DIFF
--- a/resources/js/components/resizable-table.js
+++ b/resources/js/components/resizable-table.js
@@ -360,6 +360,13 @@ import { parseJson } from '../lib/parse';
         if (!theadRow) return;
 
         theadRow.querySelectorAll('th[data-column-id]').forEach(th => {
+            if (th.hasAttribute('data-column-fixed')) {
+                th.removeAttribute('draggable');
+                th.style.cursor = '';
+                th.classList.remove('select-none');
+                return;
+            }
+
             th.setAttribute('draggable', 'true');
             th.style.cursor = 'move';
             th.classList.add('select-none');

--- a/resources/js/horizon/jobs.js
+++ b/resources/js/horizon/jobs.js
@@ -243,6 +243,17 @@ export function horizonJobsPage(config) {
             });
         },
         /**
+         * Select or clear all failed jobs from the retry modal header checkbox.
+         * @returns {void}
+         */
+        toggleAllFailedSelection() {
+            if (this.selectedFailedJobs.length > 0) {
+                this.clearSelection();
+                return;
+            }
+            this.selectAllFailed();
+        },
+        /**
          * Clear the selection.
          * @returns {void}
          */

--- a/resources/views/components/checkbox.blade.php
+++ b/resources/views/components/checkbox.blade.php
@@ -13,7 +13,7 @@
     }
 @endphp
 <div
-    class="checkbox-root"
+    class="checkbox-root flex items-center justify-center"
     x-data="{ mouseDownOnCheckbox: false }"
     x-ref="checkboxWrap"
     @mouseup.window="if (mouseDownOnCheckbox && $refs.checkboxWrap && !$refs.checkboxWrap.contains($event.target)) { $refs.checkboxWrap.querySelector('input')?.focus(); } mouseDownOnCheckbox = false"

--- a/resources/views/horizon/jobs/index.blade.php
+++ b/resources/views/horizon/jobs/index.blade.php
@@ -121,29 +121,6 @@
                                     Search
                                 </x-button>
                             </form>
-                            <div class="flex items-end gap-2">
-                                <x-button
-                                    type="button"
-                                    variant="outline"
-                                    class="h-9 text-sm inline-flex items-center justify-center gap-1 min-w-[7.5rem]"
-                                    x-bind:disabled="selectingAllFailed"
-                                    @click="selectAllFailed()"
-                                >
-                                    <span x-show="!selectingAllFailed">Select all</span>
-                                    <span x-cloak x-show="selectingAllFailed" style="display: none" class="inline-flex items-center gap-1">
-                                        <x-loader class="size-4" />
-                                        Selecting...
-                                    </span>
-                                </x-button>
-                                <x-button
-                                    type="button"
-                                    variant="ghost"
-                                    class="h-9 text-sm"
-                                    @click="clearSelection()"
-                                >
-                                    Clear selection
-                                </x-button>
-                            </div>
                         </div>
                             <div
                                 class="min-h-0 flex-1 overflow-x-auto overflow-y-auto rounded-md border border-border"
@@ -159,7 +136,19 @@
                                 >
                                     <x-slot:head>
                                         <tr class="border-b border-border">
-                                            <th class="table-header w-10 px-4 py-2.5" data-column-id="select"></th>
+                                            <th
+                                                class="table-header w-10 px-4 py-2.5 cursor-pointer"
+                                                data-column-id="select"
+                                                data-column-fixed
+                                                @click="toggleAllFailedSelection()"
+                                            >
+                                                <div class="pointer-events-none flex justify-center">
+                                                    <x-checkbox
+                                                        x-bind:checked="selectedFailedJobs.length > 0"
+                                                        aria-label="Select all failed jobs"
+                                                    />
+                                                </div>
+                                            </th>
                                             <th class="table-header px-4 py-2.5 min-w-[100px]" data-column-id="service">Service</th>
                                             <th class="table-header px-4 py-2.5 min-w-[100px]" data-column-id="queue">Queue</th>
                                             <th class="table-header px-4 py-2.5" data-column-id="job">Job</th>


### PR DESCRIPTION
- Updated the resizable table component to prevent dragging on fixed columns, improving usability.
- Added a new method to toggle selection of all failed jobs in the Horizon retry modal, enhancing job management functionality.
- Modified the Blade template to integrate the new selection method, improving user interaction with job selection.