### PR TITLE
Update Alert model and validation to enforce service selection requirements

### DIFF
--- a/app/Models/Alert.php
+++ b/app/Models/Alert.php
@@ -80,7 +80,7 @@ class Alert extends Model
     public function appliesToServiceId(int $serviceId): bool
     {
         if ($this->service_ids === []) {
-            return true;
+            return false;
         }
 
         return \in_array($serviceId, $this->service_ids, true);
@@ -103,7 +103,7 @@ class Alert extends Model
     public function resolvedServiceIds(): array
     {
         if ($this->service_ids === []) {
-            return Service::query()->enabled()->pluck('id')->all();
+            return [];
         }
 
         $ids = Service::query()

--- a/app/Services/Alerts/AlertUpsertService.php
+++ b/app/Services/Alerts/AlertUpsertService.php
@@ -111,7 +111,7 @@ class AlertUpsertService
         ];
         $baseRules = [
             'rule_type' => 'required|in:' . implode(',', $ruleTypes),
-            'service_ids' => 'nullable|array',
+            'service_ids' => 'required|array|min:1',
             'service_ids.*' => 'integer|exists:services,id',
             'queue' => 'nullable|string|max:255',
             'job_type' => 'nullable|string|max:255',

--- a/database/migrations/2026_05_19_000001_backfill_alert_service_ids_from_empty_scope.php
+++ b/database/migrations/2026_05_19_000001_backfill_alert_service_ids_from_empty_scope.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Models\Alert;
+use App\Models\Service;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $enabledServiceIds = Service::query()->enabled()->pluck('id')->all();
+
+        if ($enabledServiceIds === []) {
+            return;
+        }
+
+        \sort($enabledServiceIds);
+
+        Alert::query()
+            ->orderBy('id')
+            ->each(function (Alert $alert) use ($enabledServiceIds): void {
+                if ($alert->service_ids !== []) {
+                    return;
+                }
+
+                $alert->forceFill(['service_ids' => $enabledServiceIds])->saveQuietly();
+            });
+    }
+
+    public function down(): void
+    {
+        // Intentionally irreversible: empty scope no longer means all services.
+    }
+};

--- a/resources/views/horizon/alerts/form.blade.php
+++ b/resources/views/horizon/alerts/form.blade.php
@@ -61,6 +61,12 @@
             queueOptionalSectionOpen: {!! \Illuminate\Support\Js::from($queueOptionalSectionOpenDefault) !!},
             jobOptionalSectionOpen: {!! \Illuminate\Support\Js::from($jobOptionalSectionOpenDefault) !!},
             jobTypeOptionalSectionOpen: {!! \Illuminate\Support\Js::from($jobTypeOptionalSectionOpenDefault) !!},
+            allServicesSelected: false,
+            init() {
+                this.$nextTick(() => {
+                    this.syncAllServicesSelected();
+                });
+            },
             addJobPattern() {
                 this.jobPatterns.push('');
             },
@@ -96,6 +102,29 @@
                 if (input && !input.disabled) {
                     input.click();
                 }
+            },
+            serviceCheckboxInputs() {
+                if (!this.$refs.serviceCheckboxList) {
+                    return [];
+                }
+                return Array.from(this.$refs.serviceCheckboxList.querySelectorAll('.checkbox-root input[type=checkbox]'));
+            },
+            syncAllServicesSelected() {
+                var inputs = this.serviceCheckboxInputs();
+                this.allServicesSelected = inputs.length > 0 && inputs.every(function (input) {
+                    return input.checked;
+                });
+            },
+            toggleAllServices() {
+                var inputs = this.serviceCheckboxInputs();
+                if (inputs.length === 0) {
+                    return;
+                }
+                var selectAll = !this.allServicesSelected;
+                inputs.forEach(function (input) {
+                    input.checked = selectAll;
+                });
+                this.syncAllServicesSelected();
             }
         }"
     >
@@ -130,13 +159,24 @@
                         @error('name') <span class="text-xs text-destructive">{{ $message }}</span> @enderror
                     </div>
                     <div class="space-y-2">
-                        <x-input-label>Services</x-input-label>
-                        <p class="text-xs text-muted-foreground">Select one or more services. Leave all unchecked to apply to all services.</p>
+                        <div class="flex flex-wrap items-center justify-between gap-2">
+                            <x-input-label>Services</x-input-label>
+                            @if($services->isNotEmpty())
+                                <x-button
+                                    type="button"
+                                    variant="secondary"
+                                    class="h-8 text-xs"
+                                    @click="toggleAllServices()"
+                                    x-text="allServicesSelected ? 'Unselect all' : 'Select all'"
+                                />
+                            @endif
+                        </div>
+                        <p class="text-xs text-muted-foreground">Select at least one service. This alert only applies to the services you choose.</p>
                         @php
                             $oldServiceIds = old('service_ids', $selectedServiceIds);
                             $oldServiceIds = \is_array($oldServiceIds) ? \array_map('intval', $oldServiceIds) : [];
                         @endphp
-                        <div class="space-y-2">
+                        <div class="space-y-2" x-ref="serviceCheckboxList" @change="syncAllServicesSelected()">
                             @foreach($services as $s)
                                 <div
                                     class="flex cursor-pointer items-center gap-3 rounded-xl border border-border px-3 py-2.5 transition-colors hover:bg-muted/50"

--- a/resources/views/horizon/alerts/partials/alert-tbody.blade.php
+++ b/resources/views/horizon/alerts/partials/alert-tbody.blade.php
@@ -76,7 +76,7 @@
                         @if(\count($serviceLabels) > 0)
                             {{ \count($serviceLabels) === 1 ? $serviceLabels[0] : \implode(', ', $serviceLabels) }}
                         @else
-                            All services
+                            No services selected
                         @endif
                     </p>
                 </div>

--- a/resources/views/horizon/alerts/show.blade.php
+++ b/resources/views/horizon/alerts/show.blade.php
@@ -48,7 +48,7 @@
                             @if(\count($serviceNames) > 0)
                                 {{ \implode(', ', $serviceNames) }}
                             @else
-                                Any service
+                                No services selected
                             @endif
                         </dd>
                     </div>

--- a/tests/Unit/AlertAppliesToServiceTest.php
+++ b/tests/Unit/AlertAppliesToServiceTest.php
@@ -13,17 +13,6 @@ class AlertAppliesToServiceTest extends TestCase
     use RefreshDatabase;
 
     #[Test]
-    public function applies_to_all_when_scope_empty(): void
-    {
-        $service = Service::factory()->create();
-        $alert = Alert::factory()->create([
-            'service_ids' => [],
-        ]);
-
-        $this->assertTrue($alert->appliesToServiceId($service->id));
-    }
-
-    #[Test]
     public function applies_when_explicit_service_id_listed(): void
     {
         $service = Service::factory()->create();
@@ -34,6 +23,18 @@ class AlertAppliesToServiceTest extends TestCase
 
         $this->assertTrue($alert->appliesToServiceId($service->id));
         $this->assertFalse($alert->appliesToServiceId($other->id));
+    }
+
+    #[Test]
+    public function does_not_apply_when_scope_empty(): void
+    {
+        $service = Service::factory()->create();
+        $alert = Alert::factory()->create([
+            'service_ids' => [],
+        ]);
+
+        $this->assertFalse($alert->appliesToServiceId($service->id));
+        $this->assertSame([], $alert->resolvedServiceIds());
     }
 
     #[Test]

--- a/tests/Unit/AlertUpsertServiceValidationTest.php
+++ b/tests/Unit/AlertUpsertServiceValidationTest.php
@@ -51,6 +51,28 @@ class AlertUpsertServiceValidationTest extends TestCase
         $this->assertSame([$provider->id], $data['provider_ids']);
     }
 
+    public function test_validate_alert_requires_at_least_one_service(): void
+    {
+        $provider = NotificationProvider::query()->create([
+            'name' => 'mail',
+            'type' => NotificationProvider::TYPE_EMAIL,
+            'config' => ['to' => ['ops@example.com']],
+        ]);
+
+        $request = Request::create('/horizon/alerts', 'POST', [
+            'name' => 'alert-no-services',
+            'rule_type' => Alert::RULE_FAILURE_COUNT,
+            'thresholdCount' => 1,
+            'thresholdMinutes' => 5,
+            'provider_ids' => [$provider->id],
+            'email_interval_minutes' => 0,
+            'enabled' => true,
+        ]);
+
+        $this->expectException(ValidationException::class);
+        (new AlertUpsertService)->validateAlert($request);
+    }
+
     public function test_validate_alert_requires_seconds_for_avg_execution_time_rule(): void
     {
         $service = Service::query()->create(['name' => 'svc', 'base_url' => 'https://svc.test', 'status' => 'online']);

--- a/tests/Unit/ModelAndProviderTest.php
+++ b/tests/Unit/ModelAndProviderTest.php
@@ -28,13 +28,13 @@ class ModelAndProviderTest extends TestCase
         $this->assertTrue($alert->appliesToServiceId($s1->id));
         $this->assertFalse($alert->appliesToServiceId(999));
 
-        $globalAlert = Alert::query()->create([
-            'name' => 'global',
+        $unscopedAlert = Alert::query()->create([
+            'name' => 'unscoped',
             'service_ids' => [],
             'rule_type' => Alert::RULE_FAILURE_COUNT,
             'enabled' => true,
         ]);
-        $this->assertTrue($globalAlert->appliesToServiceId($s1->id));
+        $this->assertFalse($unscopedAlert->appliesToServiceId($s1->id));
 
         $defaultScopeAlert = new Alert([
             'name' => 'defaults',


### PR DESCRIPTION
- Change `appliesToServiceId` method to return false when no service IDs are set.
- Update `resolvedServiceIds` method to return an empty array when no service IDs are present.
- Modify validation rules in `AlertUpsertService` to require at least one service ID.
- Add migration to backfill service IDs for alerts with empty scopes.
- Enhance frontend alert forms to ensure at least one service is selected, with UI updates for selecting all services.
- Update tests to reflect changes in service ID handling and validation requirements.