### PR TITLE
Refactor logging

### DIFF
--- a/app/Jobs/EvaluateAlertJob.php
+++ b/app/Jobs/EvaluateAlertJob.php
@@ -63,7 +63,7 @@ class EvaluateAlertJob implements ShouldQueue
 
             $cache->recordEvaluationResult($engine->evaluateAlert($alert));
         } catch (\Throwable $e) {
-            Log::error(config('app.name') . ': alert evaluation job failed', [
+            Log::channel('hub')->error('alert evaluation job failed', [
                 'alert_id' => $this->alertId,
                 'evaluation_id' => $this->evaluationId,
                 'error' => $e->getMessage(),

--- a/app/Logging/PrefixAppLog.php
+++ b/app/Logging/PrefixAppLog.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Logging;
+
+use Illuminate\Log\Logger;
+use Monolog\LogRecord;
+
+class PrefixAppLog
+{
+    /**
+     * Prefix hub channel log messages with the application name.
+     */
+    public function __invoke(Logger $logger): void
+    {
+        foreach ($logger->getHandlers() as $handler) {
+            $handler->pushProcessor(function (LogRecord $record): LogRecord {
+                $prefix = "[" . config('app.name') . "] ";
+
+                if (str_starts_with($record->message, $prefix)) {
+                    return $record;
+                }
+
+                return $record->with(message: "$prefix{$record->message}");
+            });
+        }
+    }
+}

--- a/app/Services/Alerts/Engine/AlertEngine.php
+++ b/app/Services/Alerts/Engine/AlertEngine.php
@@ -72,7 +72,7 @@ class AlertEngine
             $lastSentAtBefore = $this->batchStore->getLastSentAt($alert);
             $pendingFlushed = $this->private__flushPendingIfDue($alert);
         } catch (\Throwable $e) {
-            Log::error(config('app.name') . ': evaluate alert failed while flushing pending', [
+            Log::channel('app')->error('evaluate alert failed while flushing pending', [
                 'alert_id' => $alert->id,
                 'error' => $e->getMessage(),
             ]);
@@ -105,7 +105,7 @@ class AlertEngine
                 $triggeredServiceId = $hit['service_id'];
             }
         } catch (\Throwable $e) {
-            Log::error(config('app.name') . ': evaluate alert failed', [
+            Log::channel('app')->error('evaluate alert failed', [
                 'alert_id' => $alert->id,
                 'error' => $e->getMessage(),
             ]);
@@ -116,7 +116,7 @@ class AlertEngine
             $lastSentAtAfter = $this->batchStore->getLastSentAt($alert);
             $delivered = ! empty($lastSentAtAfter) && (empty($lastSentAtBefore) || ! $lastSentAtAfter->eq($lastSentAtBefore));
         } catch (\Throwable $e) {
-            Log::error(config('app.name') . ': evaluate alert failed while checking delivery', [
+            Log::channel('app')->error('evaluate alert failed while checking delivery', [
                 'alert_id' => $alert->id,
                 'error' => $e->getMessage(),
             ]);
@@ -152,7 +152,7 @@ class AlertEngine
                 $serviceIds = $alert->resolvedServiceIds();
 
                 if ($serviceIds === []) {
-                    Log::warning(config('app.name') . ': no enabled services to evaluate alert', ['alert_id' => $alert->id]);
+                    Log::channel('app')->warning('no enabled services to evaluate alert', ['alert_id' => $alert->id]);
 
                     continue;
                 }
@@ -165,7 +165,7 @@ class AlertEngine
 
                 $this->private__triggerAlert($alert, $hit['service_id'], $hit['job_uuids']);
             } catch (\Throwable $e) {
-                Log::error(config('app.name') . ': evaluate scheduled alert failed', ['alert_id' => $alert->id, 'error' => $e->getMessage()]);
+                Log::channel('app')->error('evaluate scheduled alert failed', ['alert_id' => $alert->id, 'error' => $e->getMessage()]);
             }
         }
     }
@@ -199,7 +199,7 @@ class AlertEngine
             try {
                 $this->private__flushPendingIfDue($alert);
             } catch (\Throwable $e) {
-                Log::error(config('app.name') . ': flush pending alert failed', ['alert_id' => $alert->id, 'error' => $e->getMessage()]);
+                Log::channel('app')->error('flush pending alert failed', ['alert_id' => $alert->id, 'error' => $e->getMessage()]);
             }
         }
     }

--- a/app/Services/Alerts/Engine/AlertNotificationDispatcher.php
+++ b/app/Services/Alerts/Engine/AlertNotificationDispatcher.php
@@ -55,7 +55,7 @@ class AlertNotificationDispatcher
 
                 if ($config === null) {
                     if (! $provider->usesWebhook()) {
-                        Log::warning(config('app.name') . ': email provider has no recipients, skip', ['alert_id' => $alert->id, 'provider_id' => $provider->id]);
+                        Log::channel('app')->warning('email provider has no recipients, skip', ['alert_id' => $alert->id, 'provider_id' => $provider->id]);
                     }
 
                     continue;
@@ -63,7 +63,7 @@ class AlertNotificationDispatcher
 
                 $this->notifiers[$notifierClass]->sendBatched($alert, $events, $config);
             } catch (\Throwable $e) {
-                Log::error(config('app.name') . ': alert notification failed', ['alert_id' => $alert->id, 'provider_id' => $provider->id, 'error' => $e->getMessage()]);
+                Log::channel('app')->error('alert notification failed', ['alert_id' => $alert->id, 'provider_id' => $provider->id, 'error' => $e->getMessage()]);
                 $log->update(['status' => 'failed', 'failure_message' => $e->getMessage()]);
             }
         }

--- a/app/Services/Horizon/Concerns/HorizonHttpClient.php
+++ b/app/Services/Horizon/Concerns/HorizonHttpClient.php
@@ -91,7 +91,7 @@ class HorizonHttpClient implements HorizonHttpClientContract
 
             if ($cached !== null) {
                 if (config('app.debug')) {
-                    Log::debug(config('app.name') . ': Horizon API call (cache hit)', [
+                    Log::channel('app')->debug('Horizon API call (cache hit)', [
                         'service_id' => $service->id ?? null,
                         'service_name' => $service->name ?? null,
                         'url' => $url,
@@ -106,7 +106,7 @@ class HorizonHttpClient implements HorizonHttpClientContract
         }
 
         if (config('app.debug')) {
-            Log::debug(config('app.name') . ': Horizon API call', [
+            Log::channel('app')->debug('Horizon API call', [
                 'service_id' => $service->id ?? null,
                 'service_name' => $service->name ?? null,
                 'url' => $url,
@@ -180,7 +180,7 @@ class HorizonHttpClient implements HorizonHttpClientContract
 
             return $result;
         } catch (\Throwable $e) {
-            Log::error(config('app.name') . ': Horizon API call exception' . ($withDashboardSession ? ' (with dashboard session)' : ''), [
+            Log::channel('app')->error('Horizon API call exception' . ($withDashboardSession ? ' (with dashboard session)' : ''), [
                 'service_id' => $service->id ?? null,
                 'url' => $url,
                 'error' => $e->getMessage(),
@@ -225,7 +225,7 @@ class HorizonHttpClient implements HorizonHttpClientContract
                 ->withOptions(['cookies' => $cookieJar])
                 ->get($dashboardUrl);
         } catch (\Throwable $e) {
-            Log::warning(config('app.name') . ': failed to bootstrap Horizon dashboard session', [
+            Log::channel('app')->warning('failed to bootstrap Horizon dashboard session', [
                 'service_id' => $service->id ?? null,
                 'url' => $dashboardUrl,
                 'error' => $e->getMessage(),
@@ -235,7 +235,7 @@ class HorizonHttpClient implements HorizonHttpClientContract
         }
 
         if (! $response->ok()) {
-            Log::warning(config('app.name') . ': unexpected status when bootstrapping Horizon dashboard session', [
+            Log::channel('app')->warning('unexpected status when bootstrapping Horizon dashboard session', [
                 'service_id' => $service->id ?? null,
                 'url' => $dashboardUrl,
                 'status' => $response->status(),
@@ -248,7 +248,7 @@ class HorizonHttpClient implements HorizonHttpClientContract
         $matches = [];
 
         if (! \preg_match('/<meta\s+name=["\']csrf-token["\']\s+content=["\']([^"\']+)["\']/', $html, $matches)) {
-            Log::warning(config('app.name') . ': unable to extract CSRF token from Horizon dashboard', [
+            Log::channel('app')->warning('unable to extract CSRF token from Horizon dashboard', [
                 'service_id' => $service->id ?? null,
                 'url' => $dashboardUrl,
             ]);
@@ -382,7 +382,7 @@ class HorizonHttpClient implements HorizonHttpClientContract
         }
 
         $message = $this->private__buildErrorMessageFromResponse($response);
-        Log::warning(config('app.name') . ': Horizon API call failed ' . $logContext, [
+        Log::channel('app')->warning('Horizon API call failed ' . $logContext, [
             'service_id' => $service->id,
             'url' => $url,
             'status' => $response->status(),

--- a/app/Services/Notifiers/EmailNotifierService.php
+++ b/app/Services/Notifiers/EmailNotifierService.php
@@ -88,7 +88,7 @@ class EmailNotifierService extends AbstractAlertNotifier
 
         $notification = $this->buildNotification($alert, $events);
 
-        Log::info(config('app.name') . ': sending alert email', [
+        Log::channel('app')->info('sending alert email', [
             'alert_id' => $alert->id,
             'to' => $to,
             'event_count' => $notification['totalEventCount'],

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Logging\PrefixAppLog;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
@@ -63,6 +64,14 @@ return [
             'path' => storage_path('logs/laravel.log'),
             'level' => env('LOG_LEVEL', 'debug'),
             'replace_placeholders' => true,
+        ],
+
+        'app' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/laravel.log'),
+            'level' => env('LOG_LEVEL', 'debug'),
+            'replace_placeholders' => true,
+            'tap' => [PrefixAppLog::class],
         ],
 
         'daily' => [

--- a/tests/Unit/AlertNotificationDispatcherTest.php
+++ b/tests/Unit/AlertNotificationDispatcherTest.php
@@ -11,7 +11,6 @@ use App\Services\Notifiers\DiscordNotifierService;
 use App\Services\Notifiers\EmailNotifierService;
 use App\Services\Notifiers\SlackNotifierService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Log;
 use Tests\TestCase;
 
 class AlertNotificationDispatcherTest extends TestCase
@@ -20,8 +19,6 @@ class AlertNotificationDispatcherTest extends TestCase
 
     public function test_dispatch_marks_log_as_failed_when_notifier_throws(): void
     {
-        Log::spy();
-
         $alert = Alert::query()->create([
             'name' => 'notif2',
             'rule_type' => Alert::RULE_FAILURE_COUNT,

--- a/tests/Unit/PrefixAppLogTest.php
+++ b/tests/Unit/PrefixAppLogTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Logging\PrefixAppLog;
+use Illuminate\Log\Logger;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger as MonologLogger;
+use Tests\TestCase;
+
+class PrefixAppLogTest extends TestCase
+{
+    public function test_does_not_double_prefix_messages(): void
+    {
+        config(['app.name' => 'HorizonHub']);
+
+        $handler = new TestHandler;
+        $monolog = new MonologLogger('app', [$handler]);
+        $logger = new Logger($monolog);
+
+        (new PrefixAppLog)($logger);
+        $logger->warning('HorizonHub: already prefixed');
+
+        $this->assertSame(
+            'HorizonHub: already prefixed',
+            $handler->getRecords()[0]['message'],
+        );
+    }
+
+    public function test_prefixes_hub_log_messages_with_app_name(): void
+    {
+        config(['app.name' => 'HorizonHub']);
+
+        $handler = new TestHandler;
+        $monolog = new MonologLogger('app', [$handler]);
+        $logger = new Logger($monolog);
+
+        (new PrefixAppLog)($logger);
+        $logger->warning('email provider has no recipients, skip');
+
+        $this->assertTrue($handler->hasWarningRecords());
+        $this->assertSame(
+            'HorizonHub: email provider has no recipients, skip',
+            $handler->getRecords()[0]['message'],
+        );
+    }
+}


### PR DESCRIPTION
Use dedicated 'app' channel and add `PrefixAppLog` for message consistency

- Updated logging calls in various services and jobs to use the 'app' channel instead of the default logger.
- Introduced PrefixAppLog to prefix log messages with the application name, ensuring consistent logging format.
- Added tests for PrefixAppLog to verify correct message prefixing behavior.