### PR TITLE
Add event dispatching for select components to improve menu handling

### DIFF
--- a/resources/views/components/multiselect.blade.php
+++ b/resources/views/components/multiselect.blade.php
@@ -86,6 +86,7 @@
         placeholder: {{ json_encode($placeholder) }},
         emptyMessage: {{ json_encode($emptyMessage) }},
         openMenu() {
+            window.dispatchEvent(new CustomEvent('horizonhub-select-open'));
             this.filterQuery = '';
             this.open = true;
             var self = this;
@@ -167,6 +168,7 @@
         },
     }"
     @click.window="handleOutsideClick($event)"
+    @horizonhub-select-open.window="closeMenu()"
 >
     <select x-ref="optionSource" multiple class="sr-only" tabindex="-1" aria-hidden="true">
         {{ $slot }}

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -28,6 +28,7 @@
         placeholder: {{ json_encode($placeholder) }},
         emptyMessage: {{ json_encode($emptyMessage) }},
         openMenu() {
+            window.dispatchEvent(new CustomEvent('horizonhub-select-open'));
             this.open = true;
             var self = this;
             this.$nextTick(function () {
@@ -101,6 +102,7 @@
         $watch('open', (open) => { if (open) sync(); });
     "
     @click.window="handleOutsideClick($event)"
+    @horizonhub-select-open.window="closeMenu()"
     >
     <select x-ref="hidden"
         {{ $selectAttrs->merge(['class' => 'sr-only']) }}>


### PR DESCRIPTION
- Implemented a custom event 'horizonhub-select-open' in both multiselect and select components to manage menu state.
- Updated event listeners to close the menu when the custom event is triggered, enhancing user interaction.